### PR TITLE
Refactor custom matchers

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -114,6 +114,10 @@ test('using jest helpers to assert element states', () => {
   expect(() =>
     expect(queryByTestId('count-value')).not.toHaveTextContent('2'),
   ).toThrowError()
+
+  expect(() =>
+    expect({thisIsNot: 'an html element'}).toBeInTheDOM(),
+  ).toThrowError()
 })
 
 test('using jest helpers to check element attributes', () => {

--- a/src/jest-extensions.js
+++ b/src/jest-extensions.js
@@ -1,6 +1,5 @@
 import {
   matcherHint,
-  printReceived,
   printExpected,
   stringify,
   RECEIVED_COLOR as receivedColor,
@@ -26,9 +25,19 @@ function checkHtmlElement(htmlElement) {
   }
 }
 
-const assertMessage = (assertionName, message, received, expected) =>
-  `${matcherHint(`${assertionName}`, 'received', '')} \n${message}: ` +
-  `${printExpected(expected)} \nReceived: ${printReceived(received)}`
+function getMessage(
+  matcher,
+  expectedLabel,
+  expectedValue,
+  receivedLabel,
+  receivedValue,
+) {
+  return [
+    `${matcher}\n`,
+    `${expectedLabel}:\n  ${expectedColor(expectedValue)}`,
+    `${receivedLabel}:\n  ${receivedColor(receivedValue)}`,
+  ].join('\n')
+}
 
 function printAttribute(name, value) {
   return value === undefined ? name : `${name}=${stringify(value)}`
@@ -42,32 +51,44 @@ function getAttributeComment(name, value) {
 
 const extensions = {
   toBeInTheDOM(received) {
-    getDisplayName(received)
     return {
-      message: () =>
-        `${matcherHint(
-          `${this.isNot ? '.not' : ''}.toBeInTheDOM`,
-          'received',
-          '',
-        )} Expected the element not to be present` +
-        `\nReceived : ${printReceived(received)}`,
       pass: !!received,
+      message: () => {
+        const to = this.isNot ? 'not to' : 'to'
+        return getMessage(
+          matcherHint(
+            `${this.isNot ? '.not' : ''}.toBeInTheDOM`,
+            'element',
+            '',
+          ),
+          'Expected',
+          `element ${to} be present`,
+          'Received',
+          received,
+        )
+      },
     }
   },
 
   toHaveTextContent(htmlElement, checkWith) {
     checkHtmlElement(htmlElement)
     const textContent = htmlElement.textContent
-    const pass = matches(textContent, htmlElement, checkWith)
     return {
-      message: () =>
-        assertMessage(
-          `${this.isNot ? '.not' : ''}.toHaveTextContent`,
-          `Expected value ${this.isNot ? 'not ' : ''}equals to`,
-          htmlElement,
+      pass: matches(textContent, htmlElement, checkWith),
+      message: () => {
+        const to = this.isNot ? 'not to' : 'to'
+        return getMessage(
+          matcherHint(
+            `${this.isNot ? '.not' : ''}.toHaveTextContent`,
+            'element',
+            '',
+          ),
+          `Expected element ${to} have text content`,
           checkWith,
-        ),
-      pass,
+          'Received',
+          textContent,
+        )
+      },
     }
   },
 
@@ -82,14 +103,9 @@ const extensions = {
         : hasAttribute,
       message: () => {
         const to = this.isNot ? 'not to' : 'to'
-        const receivedAttribute = receivedColor(
-          hasAttribute
-            ? printAttribute(name, receivedValue)
-            : 'attribute was not found',
-        )
-        const expectedMsg = `Expected the element ${to} have attribute:\n  ${expectedColor(
-          printAttribute(name, expectedValue),
-        )}`
+        const receivedAttribute = hasAttribute
+          ? printAttribute(name, receivedValue)
+          : null
         const matcher = matcherHint(
           `${this.isNot ? '.not' : ''}.toHaveAttribute`,
           'element',
@@ -101,7 +117,13 @@ const extensions = {
             comment: getAttributeComment(name, expectedValue),
           },
         )
-        return `${matcher}\n\n${expectedMsg}\nReceived:\n  ${receivedAttribute}`
+        return getMessage(
+          matcher,
+          `Expected the element ${to} have attribute`,
+          printAttribute(name, expectedValue),
+          'Received',
+          receivedAttribute,
+        )
       },
     }
   },

--- a/src/jest-extensions.js
+++ b/src/jest-extensions.js
@@ -43,28 +43,15 @@ function getAttributeComment(name, value) {
 const extensions = {
   toBeInTheDOM(received) {
     getDisplayName(received)
-    if (received) {
-      return {
-        message: () =>
-          `${matcherHint(
-            '.not.toBeInTheDOM',
-            'received',
-            '',
-          )} Expected the element not to be present` +
-          `\nReceived : ${printReceived(received)}`,
-        pass: true,
-      }
-    } else {
-      return {
-        message: () =>
-          `${matcherHint(
-            '.toBeInTheDOM',
-            'received',
-            '',
-          )} Expected the element to be present` +
-          `\nReceived : ${printReceived(received)}`,
-        pass: false,
-      }
+    return {
+      message: () =>
+        `${matcherHint(
+          `${this.isNot ? '.not' : ''}.toBeInTheDOM`,
+          'received',
+          '',
+        )} Expected the element not to be present` +
+        `\nReceived : ${printReceived(received)}`,
+      pass: !!received,
     }
   },
 
@@ -72,28 +59,15 @@ const extensions = {
     checkHtmlElement(htmlElement)
     const textContent = htmlElement.textContent
     const pass = matches(textContent, htmlElement, checkWith)
-    if (pass) {
-      return {
-        message: () =>
-          assertMessage(
-            '.not.toHaveTextContent',
-            'Expected value not equals to',
-            htmlElement,
-            checkWith,
-          ),
-        pass: true,
-      }
-    } else {
-      return {
-        message: () =>
-          assertMessage(
-            '.toHaveTextContent',
-            'Expected value equals to',
-            htmlElement,
-            checkWith,
-          ),
-        pass: false,
-      }
+    return {
+      message: () =>
+        assertMessage(
+          `${this.isNot ? '.not' : ''}.toHaveTextContent`,
+          `Expected value ${this.isNot ? 'not ' : ''}equals to`,
+          htmlElement,
+          checkWith,
+        ),
+      pass,
     }
   },
 

--- a/src/jest-extensions.js
+++ b/src/jest-extensions.js
@@ -51,6 +51,9 @@ function getAttributeComment(name, value) {
 
 const extensions = {
   toBeInTheDOM(received) {
+    if (received) {
+      checkHtmlElement(received)
+    }
     return {
       pass: !!received,
       message: () => {


### PR DESCRIPTION
(re-creating https://github.com/kentcdodds/react-testing-library/pull/46)

This is a proposed refactor to the custom matchers code, as briefly discussed in https://github.com/kentcdodds/react-testing-library/pull/44#discussion_r179593891:

- [x] Use common message format across all custom matchers
- [x] Make it easy to adopt the same format in any future matchers
- [x] Simplify code, remove unneeded if/else logic

Closes #45

#### Proposed changes not yet performed (pending discussion)

- [ ] Make each custom matcher a named export, instead of bundling them in an object as default export
- [ ] Better organize in a sub folder with one file per matchers and some utils file for common stuff

#### Pending to be fixed

- [x] Code coverage is not full because `getDisplayName` never gets called during the tests with a class as argument, only with html elements. I wonder if that is expected, given that this library is only dealing with rendered html and not the virtual dom, or is it?