### PR TITLE
Add toHaveClass custom matcher (closes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ when a real user uses it.
   * [`toBeInTheDOM`](#tobeinthedom)
   * [`toHaveTextContent`](#tohavetextcontent)
   * [`toHaveAttribute`](#tohaveattribute)
+  * [`toHaveClass`](#tohaveclass)
   * [Custom Jest Matchers - Typescript](#custom-jest-matchers---typescript)
 * [`TextMatch`](#textmatch)
 * [`query` APIs](#query-apis)
@@ -361,6 +362,25 @@ expect(getByTestId(container, 'ok-button')).not.toHaveAttribute(
   'type',
   'button',
 )
+// ...
+```
+
+### `toHaveClass`
+
+This allows you to check wether the given element has certain classes within its
+`class` attribute.
+
+```javascript
+// add the custom expect matchers
+import 'dom-testing-library/extend-expect'
+
+// ...
+// <button data-testid="delete-button" class="btn extra btn-danger">
+//   Delete item
+// </button>
+expect(getByTestId(container, 'delete-button')).toHaveClass('extra')
+expect(getByTestId(container, 'delete-button')).toHaveClass('btn-danger btn')
+expect(getByTestId(container, 'delete-button')).not.toHaveClass('btn-link')
 // ...
 ```
 

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -152,9 +152,14 @@ test('using jest helpers to check element attributes', () => {
 
 test('using jest helpers to check element class names', () => {
   const {getByTestId} = render(`
-    <button data-testid="delete-button" class="btn extra btn-danger">
-      Delete item
-    </button>
+    <div>
+      <button data-testid="delete-button" class="btn extra btn-danger">
+        Delete item
+      </button>
+      <button data-testid="cancel-button">
+        Cancel
+      </button>
+    </div>
   `)
 
   expect(getByTestId('delete-button')).toHaveClass('btn')
@@ -163,6 +168,7 @@ test('using jest helpers to check element class names', () => {
   expect(getByTestId('delete-button')).not.toHaveClass('xtra')
   expect(getByTestId('delete-button')).toHaveClass('btn btn-danger')
   expect(getByTestId('delete-button')).not.toHaveClass('btn-link')
+  expect(getByTestId('cancel-button')).not.toHaveClass('btn-danger')
 
   expect(() =>
     expect(getByTestId('delete-button')).not.toHaveClass('btn'),
@@ -181,6 +187,9 @@ test('using jest helpers to check element class names', () => {
   ).toThrowError()
   expect(() =>
     expect(getByTestId('delete-button')).toHaveClass('btn-link'),
+  ).toThrowError()
+  expect(() =>
+    expect(getByTestId('cancel-button')).toHaveClass('btn-danger'),
   ).toThrowError()
 })
 

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -150,4 +150,38 @@ test('using jest helpers to check element attributes', () => {
   ).toThrowError()
 })
 
+test('using jest helpers to check element class names', () => {
+  const {getByTestId} = render(`
+    <button data-testid="delete-button" class="btn extra btn-danger">
+      Delete item
+    </button>
+  `)
+
+  expect(getByTestId('delete-button')).toHaveClass('btn')
+  expect(getByTestId('delete-button')).toHaveClass('btn-danger')
+  expect(getByTestId('delete-button')).toHaveClass('extra')
+  expect(getByTestId('delete-button')).not.toHaveClass('xtra')
+  expect(getByTestId('delete-button')).toHaveClass('btn btn-danger')
+  expect(getByTestId('delete-button')).not.toHaveClass('btn-link')
+
+  expect(() =>
+    expect(getByTestId('delete-button')).not.toHaveClass('btn'),
+  ).toThrowError()
+  expect(() =>
+    expect(getByTestId('delete-button')).not.toHaveClass('btn-danger'),
+  ).toThrowError()
+  expect(() =>
+    expect(getByTestId('delete-button')).not.toHaveClass('extra'),
+  ).toThrowError()
+  expect(() =>
+    expect(getByTestId('delete-button')).toHaveClass('xtra'),
+  ).toThrowError()
+  expect(() =>
+    expect(getByTestId('delete-button')).not.toHaveClass('btn btn-danger'),
+  ).toThrowError()
+  expect(() =>
+    expect(getByTestId('delete-button')).toHaveClass('btn-link'),
+  ).toThrowError()
+})
+
 /* eslint jsx-a11y/label-has-for:0 */

--- a/src/extend-expect.js
+++ b/src/extend-expect.js
@@ -1,4 +1,9 @@
 import extensions from './jest-extensions'
 
-const {toBeInTheDOM, toHaveTextContent, toHaveAttribute} = extensions
-expect.extend({toBeInTheDOM, toHaveTextContent, toHaveAttribute})
+const {
+  toBeInTheDOM,
+  toHaveTextContent,
+  toHaveAttribute,
+  toHaveClass,
+} = extensions
+expect.extend({toBeInTheDOM, toHaveTextContent, toHaveAttribute, toHaveClass})

--- a/src/jest-extensions.js
+++ b/src/jest-extensions.js
@@ -49,6 +49,14 @@ function getAttributeComment(name, value) {
     : `element.getAttribute(${stringify(name)}) === ${stringify(value)}`
 }
 
+function splitClassNames(str) {
+  return str.split(/\s+/).filter(s => s.length > 0)
+}
+
+function isSubset(subset, superset) {
+  return subset.every(item => superset.includes(item))
+}
+
 const extensions = {
   toBeInTheDOM(received) {
     if (received) {
@@ -126,6 +134,29 @@ const extensions = {
           printAttribute(name, expectedValue),
           'Received',
           receivedAttribute,
+        )
+      },
+    }
+  },
+
+  toHaveClass(htmlElement, expectedClassNames) {
+    checkHtmlElement(htmlElement)
+    const received = splitClassNames(htmlElement.getAttribute('class'))
+    const expected = splitClassNames(expectedClassNames)
+    return {
+      pass: isSubset(expected, received),
+      message: () => {
+        const to = this.isNot ? 'not to' : 'to'
+        return getMessage(
+          matcherHint(
+            `${this.isNot ? '.not' : ''}.toHaveClass`,
+            'element',
+            printExpected(expected.join(' ')),
+          ),
+          `Expected the element ${to} have class`,
+          expected.join(' '),
+          'Received',
+          received.join(' '),
         )
       },
     }

--- a/src/jest-extensions.js
+++ b/src/jest-extensions.js
@@ -50,6 +50,9 @@ function getAttributeComment(name, value) {
 }
 
 function splitClassNames(str) {
+  if (!str) {
+    return []
+  }
   return str.split(/\s+/).filter(s => s.length > 0)
 }
 


### PR DESCRIPTION
As discussed in #2 (closes #2)

One thing to note about it: I did this custom matcher so that it can even be used to match more than one class at the same time:

```javascript
// <button data-testid="delete-button" class="btn extra btn-danger">
//   Delete item
// </button>

// This passes, even though `"btn btn-danger"` are not contiguous in the actual class attr
expect(getByTestId('delete-button')).toHaveClass('btn btn-danger')
```

I think this makes it much more useful, and was not difficult to support.