### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ getByText(container, (content, element) => {
 
 ## `query` APIs
 
-Each of the `get` APIs listed in [the `render`](#render) section above have a
+Each of the `get` APIs listed in [the 'Usage'](#usage) section above have a
 complimentary `query` API. The `get` APIs will throw errors if a proper node
 cannot be found. This is normally the desired effect. However, if you want to
 make an assertion that an element is _not_ present in the DOM, then you can use


### PR DESCRIPTION
Though I'd rather move this section about "`query` APIs" to be right inside the "Usage" section at the end of it, after all the `get*` functions. This would remove the need for the link in the first place.

Also I was wondering if it's intentional to have `getByTestId` missing from the table of content and with a deeper level of nesting in the README outline than the other `get*` functions.