### PR TITLE
Ignore extra whitespace when matching nodes by text content

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -33,6 +33,21 @@ test('get throws a useful error message', () => {
   expect(() => getByAltText('LucyRicardo')).toThrowErrorMatchingSnapshot()
 })
 
+test('can get elements by matching their text content', () => {
+  const {queryByText} = render(`
+    <div>
+      <span>Currently showing</span>
+      <span>
+        Step
+        1
+          of 4
+      </span>
+    </div>
+  `)
+  expect(queryByText('Currently showing')).toBeInTheDOM()
+  expect(queryByText('Step 1 of 4')).toBeInTheDOM()
+})
+
 test('get can get form controls by label text', () => {
   const {getByLabelText} = render(`
     <div>

--- a/src/queries.js
+++ b/src/queries.js
@@ -71,6 +71,8 @@ function getText(node) {
     )
     .map(c => c.textContent)
     .join(' ')
+    .trim()
+    .replace(/\s+/g, ' ')
 }
 
 // getters


### PR DESCRIPTION
**What**:

This fixes kentcdodds/react-testing-library#53

When matching nodes by their text content, the extra whitespace within words in that text has to be ignored.

**Why**:

Extra whitespace within text is ignored by browsers when that text is shown to users on screen or even by screen readers. Therefore it is reasonable to assume that when matching nodes by their text content, this should be done as closely as possible to how a user of a web app does it.

**How**:

Replaced all contiguous whitespace within a text node with a single space, before using that text to match it.

**Checklist**:

* [x] Tests
* [x] Ready to be merged
