### PR TITLE
Replace reference to react specific tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ when a real user uses it.
   * [Using other assertion libraries](#using-other-assertion-libraries)
 * [`TextMatch`](#textmatch)
 * [`query` APIs](#query-apis)
-* [`bindElementToQueries`](#bindElementToQueries)
+* [`bindElementToQueries`](#bindelementtoqueries)
 * [Debugging](#debugging)
 * [Implementations](#implementations)
 * [FAQ](#faq)
@@ -635,7 +635,7 @@ I'm not aware of any! Please feel free to make a pull request to add any here.
 > [The more your tests resemble the way your software is used, the more confidence they can give you.][guiding-principle]
 
 We try to only expose methods and utilities that encourage you to write tests
-that closely resemble how your react components are used.
+that closely resemble how your web pages are used.
 
 Utilities are included in this project based on the following guiding
 principles:


### PR DESCRIPTION
This is most probably a remnant of when this lib was extracted from react-testing-library