### PR TITLE
Allow node >=6

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "engines": {
-    "node": "> 6"
+    "node": ">=6"
   },
   "scripts": {
     "add-contributor": "kcd-scripts contributors add",


### PR DESCRIPTION
Ran in to this error while trying to install with yarn

```
error dom-testing-library@1.8.0: The engine "node" is incompatible with this module. Expected version "> 6".
```

Ran with 
Node: 6.11.2
Yarn: 1.3.2
