### PR TITLE
poc for getting/querying by title

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ when a real user uses it.
   * [`getByPlaceholderText(container: HTMLElement, text: TextMatch): HTMLElement`](#getbyplaceholdertextcontainer-htmlelement-text-textmatch-htmlelement)
   * [`getByText(container: HTMLElement, text: TextMatch): HTMLElement`](#getbytextcontainer-htmlelement-text-textmatch-htmlelement)
   * [`getByAltText(container: HTMLElement, text: TextMatch): HTMLElement`](#getbyalttextcontainer-htmlelement-text-textmatch-htmlelement)
+  * [`getByTitle(container: HTMLElement, title: ExactTextMatch): HTMLElement`](#getbytitlecontainer-htmlelement-title-exacttextmatch-htmlelement)
   * [`getByTestId(container: HTMLElement, text: ExactTextMatch): HTMLElement`](#getbytestidcontainer-htmlelement-text-exacttextmatch-htmlelement)
   * [`wait`](#wait)
   * [`waitForElement`](#waitforelement)
@@ -248,6 +249,15 @@ and [`<area>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area)
 ```javascript
 // <img alt="Incredibles 2 Poster" src="/incredibles-2.png" />
 const incrediblesPosterImg = getByAltText(container, /incredibles.*poster$/i)
+```
+
+### `getByTitle(container: HTMLElement, title: ExactTextMatch): HTMLElement`
+
+This will return the element that has the matching `title` attribute.
+
+```javascript
+// <span title="Delete" id="2" />
+const deleteElement = getByTitle(container, 'Delete')
 ```
 
 ### `getByTestId(container: HTMLElement, text: ExactTextMatch): HTMLElement`

--- a/src/__tests__/__snapshots__/element-queries.js.snap
+++ b/src/__tests__/__snapshots__/element-queries.js.snap
@@ -40,6 +40,14 @@ exports[`get throws a useful error message 5`] = `
 [36m</div>[39m"
 `;
 
+exports[`get throws a useful error message 6`] = `
+"Unable to find an element with the title: LucyRicardo. 
+
+[36m<div>[39m
+  [36m<div />[39m
+[36m</div>[39m"
+`;
+
 exports[`label with no form control 1`] = `
 "Found a label with the text of: alone, however no form control was found associated to that label. Make sure you're using the \\"for\\" attribute or \\"aria-labelledby\\" attribute correctly. 
 

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -23,6 +23,7 @@ test('get throws a useful error message', () => {
     getByText,
     getByTestId,
     getByAltText,
+    getByTitle,
   } = render('<div />')
   expect(() => getByLabelText('LucyRicardo')).toThrowErrorMatchingSnapshot()
   expect(() =>
@@ -31,6 +32,7 @@ test('get throws a useful error message', () => {
   expect(() => getByText('LucyRicardo')).toThrowErrorMatchingSnapshot()
   expect(() => getByTestId('LucyRicardo')).toThrowErrorMatchingSnapshot()
   expect(() => getByAltText('LucyRicardo')).toThrowErrorMatchingSnapshot()
+  expect(() => getByTitle('LucyRicardo')).toThrowErrorMatchingSnapshot()
 })
 
 test('can get elements by matching their text content', () => {

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -117,6 +117,19 @@ test('get element by its alt text', () => {
   expect(getByAltText(/fin.*nem.*poster$/i).src).toBe('/finding-nemo.png')
 })
 
+test('query/get element by its title', () => {
+  const {getByTitle, queryByTitle} = render(`
+    <div>
+        <span title="Ignore this" id="1"/>
+        <span title="Delete" id="2"/>
+        <span title="Ignore this as well" id="3"/>
+    </div>
+  `)
+
+  expect(getByTitle('Delete').id).toEqual('2')
+  expect(queryByTitle('Delete').id).toEqual('2')
+})
+
 test('can get elements by data-testid attribute', () => {
   const {queryByTestId} = render(`<div data-testid="firstName"></div>`)
   expect(queryByTestId('firstName')).toBeInTheDOM()

--- a/src/queries.js
+++ b/src/queries.js
@@ -68,6 +68,32 @@ function queryByText(container, text, opts) {
   return firstResultOrNull(queryAllByText, container, text, opts)
 }
 
+function queryAllByTitle(container, title, {selector = '*'} = {}) {
+  return Array.from(container.querySelectorAll(selector)).filter(
+    el => el.title === title,
+  )
+}
+
+function queryByTitle(container, title, opts) {
+  return firstResultOrNull(queryAllByTitle, container, title, opts)
+}
+
+function getAllByTitle(container, title, ...rest) {
+  const els = queryAllByTitle(container, title, ...rest)
+  if (!els.length) {
+    throw new Error(
+      `Unable to find an element with the title: ${title}. \n\n${debugDOM(
+        container,
+      )}`,
+    )
+  }
+  return els
+}
+
+function getByTitle(...args) {
+  return firstResultOrNull(getAllByTitle, ...args)
+}
+
 // this is just a utility and not an exposed query.
 // There are no plans to expose this.
 function queryAllByAttribute(attribute, container, text, {exact = false} = {}) {
@@ -215,6 +241,10 @@ export {
   queryAllByTestId,
   getByTestId,
   getAllByTestId,
+  queryByTitle,
+  queryAllByTitle,
+  getByTitle,
+  getAllByTitle,
 }
 
 /* eslint complexity:["error", 14] */

--- a/src/queries.js
+++ b/src/queries.js
@@ -68,15 +68,11 @@ function queryByText(container, text, opts) {
   return firstResultOrNull(queryAllByText, container, text, opts)
 }
 
-function queryAllByTitle(container, title, {selector = '*'} = {}) {
-  return Array.from(container.querySelectorAll(selector)).filter(
-    el => el.title === title,
-  )
-}
+const queryAllByTitle = (...args) =>
+  queryAllByAttribute('title', ...args, {exact: true})
 
-function queryByTitle(container, title, opts) {
-  return firstResultOrNull(queryAllByTitle, container, title, opts)
-}
+const queryByTitle = (...args) =>
+  queryByAttribute('title', ...args, {exact: true})
 
 function getAllByTitle(container, title, ...rest) {
   const els = queryAllByTitle(container, title, ...rest)


### PR DESCRIPTION
**What**:

Add ability to get/query by title, basic test coverage for now

**Why**:

Here comes my question, I've been seeing this pattern quite a bit:
https://github.com/meteor/todos/blob/react/imports/ui/components/ListHeader.jsx#L162

I wanted to learn your thinking here - are those antipatterns? I'm rewriting above example app by the Meteor guys to Apollo backend/frontend, while using cypress-testing-library and react-testing-library to drive the work.

I'm not sure if I have any other way of accessing elements like that.

I could rewrite places like that to use img with alt instead, but I'm trying to keep the components as similar to the original ones as possible (so it will be easier to compare between meteor and apollo)

**How**:

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->