### PR TITLE
get/query by value

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ when a real user uses it.
   * [`getByText`](#getbytext)
   * [`getByAltText`](#getbyalttext)
   * [`getByTitle`](#getbytitle)
+  * [`getByValue`](#getbyvalue)
   * [`getByTestId`](#getbytestid)
   * [`wait`](#wait)
   * [`waitForElement`](#waitforelement)
@@ -318,6 +319,26 @@ Returns the element that has the matching `title` attribute.
 ```javascript
 // <span title="Delete" id="2" />
 const deleteElement = getByTitle(container, 'Delete')
+```
+
+### `getByValue`
+
+```typescript
+getByValue(
+  container: HTMLElement,
+  value: TextMatch,
+  options?: {
+    exact?: boolean = true,
+    collapseWhitespace?: boolean = false,
+    trim?: boolean = true,
+  }): HTMLElement
+```
+
+Returns the element that has the matching value.
+
+```javascript
+// <input type="text" id="lastName" defaultValue="Norris" />
+const lastNameInput = getByValue('Norris')
 ```
 
 ### `getByTestId`

--- a/src/__tests__/__snapshots__/element-queries.js.snap
+++ b/src/__tests__/__snapshots__/element-queries.js.snap
@@ -48,6 +48,14 @@ exports[`get throws a useful error message 6`] = `
 [36m</div>[39m"
 `;
 
+exports[`get throws a useful error message 7`] = `
+"Unable to find an element with the value: LucyRicardo. 
+
+[36m<div>[39m
+  [36m<div />[39m
+[36m</div>[39m"
+`;
+
 exports[`label with no form control 1`] = `
 "Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the \\"for\\" attribute or \\"aria-labelledby\\" attribute correctly. 
 

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -135,18 +135,16 @@ test('query/get element by its title', () => {
 })
 
 test('query/get element by its value', () => {
-  const {getByValue, queryByValue, getByPlaceholderText} = render(`
+  const {getByValue, queryByValue} = render(`
   <div>
-    <input placeholder="name" type="text" id="name"/>
-    <input placeholder="lastname" type="text" id="lastname"/>
-    <input placeholder="email" type="text" id="email"/>
+    <input placeholder="name" type="text"/>
+    <input placeholder="lastname" type="text" value="Norris"/>
+    <input placeholder="email" type="text"/>
   </div>
   `)
 
-  getByPlaceholderText('lastname').setAttribute('value', 'Norris')
-
-  expect(queryByValue('Norris').id).toEqual('lastname')
-  expect(getByValue('Norris').id).toEqual('lastname')
+  expect(queryByValue('Norris').placeholder).toEqual('lastname')
+  expect(getByValue('Norris').placeholder).toEqual('lastname')
 })
 
 test('can get elements by data-testid attribute', () => {

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -24,6 +24,7 @@ test('get throws a useful error message', () => {
     getByTestId,
     getByAltText,
     getByTitle,
+    getByValue,
   } = render('<div />')
   expect(() => getByLabelText('LucyRicardo')).toThrowErrorMatchingSnapshot()
   expect(() =>
@@ -33,6 +34,7 @@ test('get throws a useful error message', () => {
   expect(() => getByTestId('LucyRicardo')).toThrowErrorMatchingSnapshot()
   expect(() => getByAltText('LucyRicardo')).toThrowErrorMatchingSnapshot()
   expect(() => getByTitle('LucyRicardo')).toThrowErrorMatchingSnapshot()
+  expect(() => getByValue('LucyRicardo')).toThrowErrorMatchingSnapshot()
 })
 
 test('can get elements by matching their text content', () => {
@@ -130,6 +132,21 @@ test('query/get element by its title', () => {
 
   expect(getByTitle('Delete').id).toEqual('2')
   expect(queryByTitle('Delete').id).toEqual('2')
+})
+
+test('query/get element by its value', () => {
+  const {getByValue, queryByValue, getByPlaceholderText} = render(`
+  <div>
+    <input placeholder="name" type="text" id="name"/>
+    <input placeholder="lastname" type="text" id="lastname"/>
+    <input placeholder="email" type="text" id="email"/>
+  </div>
+  `)
+
+  getByPlaceholderText('lastname').setAttribute('value', 'Norris')
+
+  expect(queryByValue('Norris').id).toEqual('lastname')
+  expect(getByValue('Norris').id).toEqual('lastname')
 })
 
 test('can get elements by data-testid attribute', () => {

--- a/src/queries.js
+++ b/src/queries.js
@@ -112,6 +112,8 @@ const queryByTestId = queryByAttribute.bind(null, 'data-testid')
 const queryAllByTestId = queryAllByAttribute.bind(null, 'data-testid')
 const queryByTitle = queryByAttribute.bind(null, 'title')
 const queryAllByTitle = queryAllByAttribute.bind(null, 'title')
+const queryByValue = queryByAttribute.bind(null, 'value')
+const queryAllByValue = queryAllByAttribute.bind(null, 'value')
 
 function queryAllByAltText(
   container,
@@ -164,6 +166,22 @@ function getAllByTitle(container, title, ...rest) {
 
 function getByTitle(...args) {
   return firstResultOrNull(getAllByTitle, ...args)
+}
+
+function getAllByValue(container, value, ...rest) {
+  const els = queryAllByValue(container, value, ...rest)
+  if (!els.length) {
+    throw new Error(
+      `Unable to find an element with the value: ${value}. \n\n${debugDOM(
+        container,
+      )}`,
+    )
+  }
+  return els
+}
+
+function getByValue(...args) {
+  return firstResultOrNull(getAllByValue, ...args)
 }
 
 function getAllByPlaceholderText(container, text, ...rest) {
@@ -264,6 +282,10 @@ export {
   queryAllByTitle,
   getByTitle,
   getAllByTitle,
+  queryByValue,
+  queryAllByValue,
+  getByValue,
+  getAllByValue,
 }
 
 /* eslint complexity:["error", 14] */


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

get/query by value

**Why**:

as per discussion in #34 

Note: setting .value on an element here somehow doesn't work, so i used .setAttribute. I linked it to my react project, and it worked with .value just fine. Not sure what's going on here.
I changed the selector part here to * instead of [${attribute}] to verify that that's not the cause:
```javascript
return Array.from(container.querySelectorAll(`[${attribute}]`)).filter(node =>
```
but it didn't change anything.

Another note, related to that, in my original implementation in my project I used a selector for getting all inputs, I guess if someone set an attribute value on a div, current implementation would get that element as well - not sure how much we want to prevent such edge cases. It's a decision between complicating the code a bit, and making sure we treat values only when they are actually input values.  

**How**:

Following the existing pattern

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->