### PR TITLE
Merge waitForElement into wait

### DIFF
--- a/src/__tests__/wait-for-element.js
+++ b/src/__tests__/wait-for-element.js
@@ -1,4 +1,4 @@
-import {waitForElement, wait} from '../'
+import {wait} from '../'
 // adds special assertions like toBeInTheDOM
 import 'jest-dom/extend-expect'
 import {render} from './helpers/test-utils'
@@ -66,10 +66,7 @@ test('it waits for the callback to return a value and only reacts to DOM mutatio
   const successHandler = jest.fn().mockName('successHandler')
   const errorHandler = jest.fn().mockName('errorHandler')
 
-  const promise = waitForElement(callback, {container}).then(
-    successHandler,
-    errorHandler,
-  )
+  const promise = wait(callback, {container}).then(successHandler, errorHandler)
 
   // One synchronous `callback` call is expected.
   expect(callback).toHaveBeenCalledTimes(1)
@@ -104,7 +101,10 @@ test('it waits for the next DOM mutation with default callback', async () => {
   const successHandler = jest.fn().mockName('successHandler')
   const errorHandler = jest.fn().mockName('errorHandler')
 
-  const promise = waitForElement().then(successHandler, errorHandler)
+  const promise = wait(undefined, {container: document}).then(
+    successHandler,
+    errorHandler,
+  )
 
   // Promise callbacks are always asynchronous.
   expect(successHandler).toHaveBeenCalledTimes(0)
@@ -138,7 +138,7 @@ test('it waits for the attributes mutation if configured', async () => {
   const successHandler = jest.fn().mockName('successHandler')
   const errorHandler = jest.fn().mockName('errorHandler')
 
-  const promise = waitForElement(callback, {
+  const promise = wait(callback, {
     container,
     mutationObserverOptions: {attributes: true},
   }).then(successHandler, errorHandler)
@@ -171,7 +171,7 @@ test('it throws if timeout is exceeded', async () => {
   const successHandler = jest.fn().mockName('successHandler')
   const errorHandler = jest.fn().mockName('errorHandler')
 
-  const promise = waitForElement(callback, {
+  const promise = wait(callback, {
     container,
     timeout: 70,
     mutationObserverOptions: {attributes: true},
@@ -207,7 +207,7 @@ test('it throws the same error that the callback has thrown if timeout is exceed
   const successHandler = jest.fn().mockName('successHandler')
   const errorHandler = jest.fn().mockName('errorHandler')
 
-  const promise = waitForElement(callback, {
+  const promise = wait(callback, {
     container,
     timeout: 70,
     mutationObserverOptions: {attributes: true},
@@ -247,7 +247,7 @@ test('it returns immediately if the callback returns the value before any mutati
   const successHandler = jest.fn().mockName('successHandler')
   const errorHandler = jest.fn().mockName('errorHandler')
 
-  const promise = waitForElement(callback, {
+  const promise = wait(callback, {
     container,
     timeout: 70,
     mutationObserverOptions: {attributes: true},

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,10 @@ export {queries}
 
 export * from './queries'
 export * from './wait'
+
+// waitForElement was merged into wait. Remove this in the next major version bump.
 export * from './wait-for-element'
+
 export * from './matches'
 export * from './get-node-text'
 export * from './events'

--- a/src/wait.js
+++ b/src/wait.js
@@ -1,7 +1,22 @@
 import waitForExpect from 'wait-for-expect'
+import {waitForElement} from './wait-for-element'
 
-function wait(callback = () => {}, {timeout = 4500, interval = 50} = {}) {
-  return waitForExpect(callback, timeout, interval)
+const noop = () => {}
+
+function wait(
+  callback = undefined,
+  {
+    timeout = 4500,
+    interval = 50,
+
+    // waitForElement will handle the default options for the following properties.
+    container,
+    mutationObserverOptions,
+  } = {},
+) {
+  return container
+    ? waitForElement(callback, {container, timeout, mutationObserverOptions})
+    : waitForExpect(callback || noop, timeout, interval)
 }
 
 export {wait}


### PR DESCRIPTION
**What**:

We are trying to merge `waitForElement` into `wait`.

See https://github.com/kentcdodds/dom-testing-library/issues/57 for details.

**Why**:

To simplify the API.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
