### PR TITLE
fix: Make 2nd arg for getQueriesForElement optional and export within for TS types

### DIFF
--- a/typings/get-queries-for-element.d.ts
+++ b/typings/get-queries-for-element.d.ts
@@ -12,7 +12,7 @@ export type BoundFunctions<T> = {[P in keyof T]: BoundFunction<T[P]>}
 
 export function getQueriesForElement(
   element: HTMLElement,
-  queriesToBind:
+  queriesToBind?:
     | BoundFunctions<typeof queries>
     | BoundFunctions<typeof queries>[],
 ): BoundFunctions<typeof queries>

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,8 +1,10 @@
 // TypeScript Version: 2.8
+import {getQueriesForElement} from './get-queries-for-element'
 import * as queries from './queries'
 import * as queryHelpers from './query-helpers'
 
-export {queries, queryHelpers}
+declare const within: typeof getQueriesForElement
+export {queries, queryHelpers, within}
 
 export * from './queries'
 export * from './query-helpers'


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes TypeScript definition for getQueriesForElement by making second argument optional. Also exports `within`.

**Why**:

This matches the actual dom-testing-library API

**How**:

By updating the TS Type definition files

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation N/A
* [x] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
