### PR TITLE
Use extend-expect directly from jest-dom

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ import {
   wait,
 } from 'dom-testing-library'
 // adds special assertions like toHaveTextContent and toBeInTheDOM
-import 'dom-testing-library/extend-expect'
+import 'jest-dom/extend-expect'
 
 function getExampleDOM() {
   // This is just a raw example of setting up some DOM
@@ -534,13 +534,13 @@ finding elements in the DOM similarly to how users would do.
 
 ## Custom Jest Matchers
 
-When using [jest][], we recommend that you import a set of custom matchers that
-make it easier to check several aspects of the state of a DOM element. These are
-provided by [jest-dom](https://github.com/gnapse/jest-dom), but are also
-included for convenience to be imported from this library directly:
+When using [jest][], it is convenient to import a set of custom matchers that
+make it easier to check several aspects of the state of a DOM element. For
+exmaple, you can use the ones provided by
+[jest-dom](https://github.com/gnapse/jest-dom):
 
 ```javascript
-import 'dom-testing-library/extend-expect'
+import 'jest-dom/extend-expect'
 
 // <span data-testid="greetings">Hello World</span>
 expect(queryByTestId(container, 'greetings')).toBeInTheDOM()

--- a/extend-expect.js
+++ b/extend-expect.js
@@ -1,2 +1,0 @@
-// eslint-disable-next-line
-require('jest-dom/extend-expect')

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
     "typings"
   ],
   "dependencies": {
-    "jest-dom": "^1.0.0",
     "pretty-format": "^22.4.3",
     "mutationobserver-shim": "^0.3.2",
     "wait-for-expect": "^0.4.0"
   },
   "devDependencies": {
     "dtslint": "^0.3.0",
+    "jest-dom": "^1.7.0",
     "jest-in-case": "^1.0.2",
     "kcd-scripts": "^0.37.0",
     "microbundle": "^0.4.4"

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
   },
   "files": [
     "dist",
-    "typings",
-    "extend-expect.js"
+    "typings"
   ],
   "dependencies": {
     "jest-dom": "^1.0.0",


### PR DESCRIPTION
**What**:

Remove extend-expect from this library.

**Why**:

Users should directly import the same functionality from jest-dom

**How**:

Removing the file and changing the documentation around it, and its reference from package.json

**Checklist**:

* [x] Documentation
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Closes #69 