### PR TITLE
fix: Reference Node and MutationObserver off of the window object

### DIFF
--- a/src/get-node-text.js
+++ b/src/get-node-text.js
@@ -1,7 +1,8 @@
 function getNodeText(node) {
   return Array.from(node.childNodes)
     .filter(
-      child => child.nodeType === Node.TEXT_NODE && Boolean(child.textContent),
+      child =>
+        child.nodeType === window.Node.TEXT_NODE && Boolean(child.textContent),
     )
     .map(c => c.textContent)
     .join(' ')

--- a/src/wait-for-element.js
+++ b/src/wait-for-element.js
@@ -46,7 +46,7 @@ function waitForElement(
       onDone(lastError || new Error('Timed out in waitForElement.'), null)
     }
     timer = setTimeout(onTimeout, timeout)
-    observer = new MutationObserver(onMutation)
+    observer = new window.MutationObserver(onMutation)
     observer.observe(container, mutationObserverOptions)
     if (callback !== undefined) {
       onMutation()


### PR DESCRIPTION
fix: Reference Node and MutationObserver off of the window object rather than globally

You have to handle shims yourself if not using jest without this

**What**:
Changes references to `Node` and `MutationObserver` to use `window` rather than globally.

**Why**:
The polyfills/shims do not work in a non-jest environment

**How**:
`Node` -> `window.Node`
`MutationObserver` -> `window.MutationObserver`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
