### PR TITLE
feat(fireEvent): helper to assign target properties to node

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,17 @@ fireEvent.click(getByText('Submit'), rightClick)
 // default `button` property for click events is set to `0` which is a left click.
 ```
 
+**target**: When an event is dispatched on an element, the event has the
+subjected element on a property called `target`. As a convenience, if you
+provide a `target` property in the `eventProperties` (second argument), then
+those properties will be assigned to the node which is receiving the event.
+
+This is particularly useful for a change event:
+
+```javascript
+fireEvent.change(getByLabelText(/username/i), {target: {value: 'a'}})
+```
+
 #### `getNodeText`
 
 ```typescript

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -1,4 +1,4 @@
-import {fireEvent} from '../'
+import {fireEvent} from '..'
 
 const eventTypes = [
   {
@@ -148,4 +148,23 @@ describe(`Aliased Events`, () => {
     fireEvent.doubleClick(node)
     expect(spy).toHaveBeenCalledTimes(1)
   })
+})
+
+test('assigns target properties', () => {
+  const node = document.createElement('input')
+  const spy = jest.fn()
+  const value = 'a'
+  node.addEventListener('change', spy)
+  fireEvent.change(node, {target: {value}})
+  expect(spy).toHaveBeenCalledTimes(1)
+  expect(node.value).toBe(value)
+})
+
+test('assigning a value to a target that cannot have a value throws an error', () => {
+  const node = document.createElement('div')
+  expect(() =>
+    fireEvent.change(node, {target: {value: 'a'}}),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"The given element does not have a value setter"`,
+  )
 })


### PR DESCRIPTION
**What**: feat(fireEvent): helper to assign target properties to node

<!-- Why are these changes necessary? -->

**Why**: Specifically this is so the change event can set the value of the node
in a way that works for React (and all other frameworks and
non-frameworks) nicely.

fixes: https://github.com/kentcdodds/react-testing-library/issues/152


<!-- How were these changes implemented? -->

**How**: Add some logic to the `fireEvent` utility, and borrow some code from a thread in react issues.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
