### PR TITLE
fix: upgrade wait-for-expect to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "pretty-format": "^22.4.3",
     "mutationobserver-shim": "^0.3.2",
-    "wait-for-expect": "^0.4.0"
+    "wait-for-expect": "^1.0.0"
   },
   "devDependencies": {
     "dtslint": "^0.3.0",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Dep upgrade

<!-- Why are these changes necessary? -->

**Why**:
I noticed I got both 0.4.0 and 1.0.0 in my lockfile when installing react-testing-library

<!-- How were these changes implemented? -->

**How**:
GitHub UI

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
