### PR TITLE
New: add async findBy queries

### DIFF
--- a/src/__tests__/element-queries-async.js
+++ b/src/__tests__/element-queries-async.js
@@ -1,0 +1,100 @@
+import 'jest-dom/extend-expect'
+import {waitFor} from '../query-helpers'
+import {render} from './helpers/test-utils'
+
+test('findBy* queries poll for element', async () => {
+  const {container, findByTestId} = render(
+    `<div data-testid="initial-id"></div>`,
+  )
+
+  setTimeout(() => {
+    container.firstChild.setAttribute('data-testid', 'final-id')
+  }, 50)
+
+  const element = await findByTestId(/final/)
+  expect(element).not.toBeNull()
+  expect(element).toMatchInlineSnapshot(`
+<div
+  data-testid="final-id"
+/>
+`)
+})
+
+test('it throws if timeout is exceeded', async () => {
+  expect.assertions(3)
+
+  const timeout = 50
+
+  const {findByText} = render(`<div>The text</div>`)
+
+  await expect(findByText('Not the text', {timeout})).rejects.toBeDefined()
+
+  await expect(findByText(/Not the/, {timeout})).rejects.toMatchInlineSnapshot(`
+[Error: Unable to find an element with the text: /Not the/. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
+
+[36m<div>[39m
+  [36m<div>[39m
+    [0mThe text[0m
+  [36m</div>[39m
+[36m</div>[39m]
+`)
+
+  try {
+    await findByText('not-there', {timeout})
+  } catch (err) {
+    expect(err).toMatchInlineSnapshot(`
+[Error: Unable to find an element with the text: not-there. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
+
+[36m<div>[39m
+  [36m<div>[39m
+    [0mThe text[0m
+  [36m</div>[39m
+[36m</div>[39m]
+`)
+  }
+})
+
+test('takes timeout as an option from last argument', async () => {
+  const {container, findByTestId} = render(
+    `<div data-testid="initial-id"></div>`,
+  )
+
+  const timeout = 50
+
+  setTimeout(() => {
+    container.firstChild.setAttribute('data-testid', 'final-id')
+  }, timeout * 2)
+
+  await expect(findByTestId('final-id', {timeout})).rejects.toBeDefined()
+})
+
+test('calling waitFor with additional arguments invokes function', async () => {
+  const {container, getByTestId} = render(
+    `<div data-testid="initial-id"></div>`,
+  )
+
+  setTimeout(() => {
+    container.firstChild.setAttribute('data-testid', 'final-id')
+  }, 50)
+
+  const el = await waitFor(getByTestId, 'final-id')
+
+  expect(container.firstChild).toBe(el)
+})
+
+test('waitFor on a function that returns null times out', async () => {
+  // the main way to keep polling is to throw an error, but returning null works too
+  const {container, queryByTestId} = render(
+    `<div data-testid="initial-id"></div>`,
+  )
+
+  const timeout = 50
+
+  setTimeout(() => {
+    container.firstChild.setAttribute('data-testid', 'final-id')
+  }, timeout * 2)
+
+  await expect(
+    waitFor(queryByTestId, 'final-id', {timeout}),
+  ).rejects.toBeDefined()
+})

--- a/src/queries.js
+++ b/src/queries.js
@@ -5,6 +5,7 @@ import {
   firstResultOrNull,
   queryAllByAttribute,
   queryByAttribute,
+  waitFor,
 } from './query-helpers'
 
 // Here are the queries for the library.
@@ -145,6 +146,8 @@ function getByTestId(...args) {
   return firstResultOrNull(getAllByTestId, ...args)
 }
 
+const findByTestId = waitFor(getByTestId)
+
 function getAllByTitle(container, title, ...rest) {
   const els = queryAllByTitle(container, title, ...rest)
   if (!els.length) {
@@ -159,6 +162,8 @@ function getAllByTitle(container, title, ...rest) {
 function getByTitle(...args) {
   return firstResultOrNull(getAllByTitle, ...args)
 }
+
+const findByTitle = waitFor(getByTitle)
 
 function getAllByValue(container, value, ...rest) {
   const els = queryAllByValue(container, value, ...rest)
@@ -175,6 +180,8 @@ function getByValue(...args) {
   return firstResultOrNull(getAllByValue, ...args)
 }
 
+const findByValue = waitFor(getByValue)
+
 function getAllByPlaceholderText(container, text, ...rest) {
   const els = queryAllByPlaceholderText(container, text, ...rest)
   if (!els.length) {
@@ -189,6 +196,8 @@ function getAllByPlaceholderText(container, text, ...rest) {
 function getByPlaceholderText(...args) {
   return firstResultOrNull(getAllByPlaceholderText, ...args)
 }
+
+const findByPlaceholderText = waitFor(getByPlaceholderText)
 
 function getAllByLabelText(container, text, ...rest) {
   const els = queryAllByLabelText(container, text, ...rest)
@@ -213,6 +222,8 @@ function getByLabelText(...args) {
   return firstResultOrNull(getAllByLabelText, ...args)
 }
 
+const findByLabelText = waitFor(getByLabelText)
+
 function getAllByText(container, text, ...rest) {
   const els = queryAllByText(container, text, ...rest)
   if (!els.length) {
@@ -227,6 +238,8 @@ function getAllByText(container, text, ...rest) {
 function getByText(...args) {
   return firstResultOrNull(getAllByText, ...args)
 }
+
+const findByText = waitFor(getByText)
 
 function getAllByAltText(container, alt, ...rest) {
   const els = queryAllByAltText(container, alt, ...rest)
@@ -243,6 +256,8 @@ function getByAltText(...args) {
   return firstResultOrNull(getAllByAltText, ...args)
 }
 
+const findByAltText = waitFor(getByAltText)
+
 function getAllByRole(container, id, ...rest) {
   const els = queryAllByRole(container, id, ...rest)
   if (!els.length) {
@@ -255,39 +270,49 @@ function getByRole(...args) {
   return firstResultOrNull(getAllByRole, ...args)
 }
 
+const findByRole = waitFor(getAllByRole)
+
 export {
   queryByPlaceholderText,
   queryAllByPlaceholderText,
   getByPlaceholderText,
+  findByPlaceholderText,
   getAllByPlaceholderText,
   queryByText,
   queryAllByText,
   getByText,
+  findByText,
   getAllByText,
   queryByLabelText,
   queryAllByLabelText,
   getByLabelText,
+  findByLabelText,
   getAllByLabelText,
   queryByAltText,
   queryAllByAltText,
   getByAltText,
+  findByAltText,
   getAllByAltText,
   queryByTestId,
   queryAllByTestId,
   getByTestId,
+  findByTestId,
   getAllByTestId,
   queryByTitle,
   queryAllByTitle,
   getByTitle,
+  findByTitle,
   getAllByTitle,
   queryByValue,
   queryAllByValue,
   getByValue,
+  findByValue,
   getAllByValue,
   queryByRole,
   queryAllByRole,
   getAllByRole,
   getByRole,
+  findByRole,
 }
 
 /* eslint complexity:["error", 14] */

--- a/src/query-helpers.js
+++ b/src/query-helpers.js
@@ -47,10 +47,64 @@ function queryByAttribute(...args) {
   return firstResultOrNull(queryAllByAttribute, ...args)
 }
 
+const DEFAULT_TIMEOUT = 4500 // milliseconds
+const POLL_INTERVAL = 10 // milliseconds
+
+async function delay(delayMs) {
+  await new Promise(resolve => setTimeout(resolve, delayMs))
+}
+
+/**
+ * creates polling function
+ * @example waitFor(getByTestId)('my-id')
+ * @example waitFor(getByTestId, 'my-id')
+ * @param {function} callback - function or async function
+ * @param {*} args - if more than 1 argument is passed,
+ *                   result function is invoked immediately
+ *                   with remaining arguments
+ * @returns {function} polling function
+ */
+function waitFor(callback, ...callbackArgs) {
+  /**
+   * retries callback until it returns a non-null value or timeout is exceeded
+   * @param {any} args - argument list for query
+   * @returns {Promise<HTMLElement, Error>} HTMLElement or Error
+   */
+  async function pollingFunction(...args) {
+    // get timeout setting from last argument (should be an "options" object):
+    const options = args[args.length - 1]
+    const timeout = options.timeout || DEFAULT_TIMEOUT
+
+    const startedAt = Date.now()
+    let lastErr = new Error('Query timed out')
+    let hasTimedOut = false
+
+    /* eslint-disable no-await-in-loop */
+    while (!hasTimedOut) {
+      try {
+        const result = await callback(...args)
+        if (result !== null) return result
+      } catch (err) {
+        lastErr = err
+      }
+      hasTimedOut = Date.now() - startedAt > timeout
+      await delay(POLL_INTERVAL)
+    }
+    throw lastErr
+  }
+
+  if (callbackArgs.length > 0) {
+    return pollingFunction(...callbackArgs)
+  } else {
+    return pollingFunction
+  }
+}
+
 export {
   debugDOM,
   getElementError,
   firstResultOrNull,
   queryAllByAttribute,
   queryByAttribute,
+  waitFor,
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Add async queries. I'm prefixing them with "findBy" for now.

All the `find` queries return a Promise and retry automatically using polling.

```js
const { findByText, findByTitle } = render(<Comp />)

let btn = await findByText('click me')
// something async happens...
expect(await findByTitle('click count')).toHaveTextContent('Clicked 1 time')
```

There is also a utility function called `waitFor` exposed that is similar to wait/waitForElement but curried:

```js
import { waitFor } from 'dom-testing-library'
const { getByText, container } = render(<Comp />)

const waitForLink = waitFor(href => container.querySelector(`[href=${href}]`))

let btn = await waitFor(getByText, 'click me')

expect(await waitForLink('/home')).not.toBeNull()
```

Note: there are *not* any `findAll` queries yet, though could easily be added by wrapping the `getAll` functions. I think the results may be confusing in an async environment if elements are loading at different times.

<!-- Why are these changes necessary? -->

**Why**:

This simplifies working with async events, which are very common in environments like Cypress or Puppeteer.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
