### PR TITLE
Ensure waitForElement disconnects MutationObserver at the right time

### DIFF
--- a/src/wait-for-element.js
+++ b/src/wait-for-element.js
@@ -18,7 +18,7 @@ function waitForElement(
     let lastError, observer, timer // eslint-disable-line prefer-const
     function onDone(error, result) {
       clearTimeout(timer)
-      observer.disconnect()
+      setImmediate(() => observer.disconnect())
       if (error) {
         reject(error)
       } else {

--- a/src/wait-for-element.js
+++ b/src/wait-for-element.js
@@ -18,7 +18,7 @@ function waitForElement(
     let lastError, observer, timer // eslint-disable-line prefer-const
     function onDone(error, result) {
       clearTimeout(timer)
-      setImmediate(() => observer.disconnect())
+      observer.disconnect()
       if (error) {
         reject(error)
       } else {


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: #99 waitForElement gets into infinite setTimeout loop

<!-- Why are these changes necessary? -->

**Why**: without the change MutationObserver gets into infinite setTimeout loop

<!-- How were these changes implemented? -->

**How**: disconnect the MutationObserver from setImmediate callback to ensure we're not in MutationObserver's `onMutate` callback when disconnecting it.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
