### PR TITLE
Minor fix to README markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,12 +594,12 @@ import 'jest-dom/extend-expect'
 // <span data-testid="greetings">Hello World</span>
 expect(queryByTestId(container, 'greetings')).not.toHaveTextContent('Bye bye')
 // ...
+```
 
 > Note: when using some of these matchers, you may need to make sure
 > you use a query function (like `queryByTestId`) rather than a get
 > function (like `getByTestId`). Otherwise the `get*` function could
 > throw an error before your assertion.
-```
 
 Check out [jest-dom's documentation](https://github.com/gnapse/jest-dom#readme)
 for a full list of available matchers.


### PR DESCRIPTION
**What**:

Change code section boundary to the proper place.

**Why**:

Some text meant to be part of markdown was incorrectly being rendered as part of a code section.

**Checklist**:

- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
