### PR TITLE
feat(events): add the capability to await events

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -1,4 +1,4 @@
-import {fireEvent} from '..'
+import {fireEvent, wait} from '..'
 
 const eventTypes = [
   {
@@ -160,11 +160,11 @@ test('assigns target properties', () => {
   expect(node.value).toBe(value)
 })
 
-test('assigning a value to a target that cannot have a value throws an error', () => {
+test('assigning a value to a target that cannot have a value throws an error', async () => {
   const node = document.createElement('div')
-  expect(() =>
+  await expect(
     fireEvent.change(node, {target: {value: 'a'}}),
-  ).toThrowErrorMatchingInlineSnapshot(
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
     `"The given element does not have a value setter"`,
   )
 })
@@ -176,4 +176,12 @@ test('assigning the files property on an input', () => {
   })
   fireEvent.change(node, {target: {files: [file]}})
   expect(node.files).toEqual([file])
+})
+
+test('can await events', async () => {
+  const node = document.createElement('button')
+  const asyncSpy = jest.fn()
+  node.addEventListener('click', () => wait().then(asyncSpy))
+  await fireEvent.click(node)
+  expect(asyncSpy).toHaveBeenCalledTimes(1)
 })

--- a/src/events.js
+++ b/src/events.js
@@ -1,3 +1,5 @@
+import {wait} from './wait'
+
 const {
   AnimationEvent,
   ClipboardEvent,
@@ -319,7 +321,7 @@ function fireEvent(element, event) {
 Object.entries(eventMap).forEach(([key, {EventType = Event, defaultInit}]) => {
   const eventName = key.toLowerCase()
 
-  fireEvent[key] = (node, init) => {
+  fireEvent[key] = async (node, init) => {
     const eventInit = {...defaultInit, ...init}
     const {target: {value, files, ...targetProperties} = {}} = eventInit
     Object.assign(node, targetProperties)
@@ -335,7 +337,9 @@ Object.entries(eventMap).forEach(([key, {EventType = Event, defaultInit}]) => {
       })
     }
     const event = new EventType(eventName, eventInit)
-    return fireEvent(node, event)
+    const ret = fireEvent(node, event)
+    await wait() // allows events to be await-ed
+    return ret
   }
 })
 


### PR DESCRIPTION
**What**: add the capability to await events

```javascript
// currently
fireEvent.click(button)
// wait for next tick:
await wait()
// assert something that happens on the next tick

// with this change:
await fireEvent.click(button)
// assert something that happens on the next tick
```

<!-- Why are these changes necessary? -->

**Why**: @alexkrolick has brought it up numerous times and some frameworks render on the next-tick rather then synchronously like React does. Allowing users to await events will significantly simplify those scenarios.

<!-- How were these changes implemented? -->

**How**: I had considered exposing a new object called `fireEventAsync`, but I think this is even better.

Tradeoffs:

1. `dispatchEvent` is _not_ async. "The return value is false if event is cancelable and at least one of the event handlers which handled this event called Event.preventDefault(). Otherwise it returns true." ([mdn](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent)). With this change, people wont be able to get the return value until the next tick. I do not consider this a very common use-case. If it comes up that people want a synchronous version of this, then perhaps we can discuss something, but I doubt it.
2. The `wait` call happens regardless of whether people are using `await`. I don't consider this a problem because it's completely unobservable and there are no side-effects.

Bottom line: People can continue doing things as they are, but if they want to wait for the next tick of the event loop (to wait for a mocked HTTP call to resolve for example), then they can simply add `await` and it'll work fine.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A

<!-- feel free to add additional comments -->


cc @sompylasar, I'd like to hear your feedback on this.