### PR TITLE
feat(getByText): add ignore option which defaults to `'script'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ getByText(
     exact?: boolean = true,
     collapseWhitespace?: boolean = true,
     trim?: boolean = true,
+    ignore?: string|boolean = 'script'
   }): HTMLElement
 ```
 
@@ -309,6 +310,14 @@ const aboutAnchorNode = getByText(container, 'about')
 ```
 
 > NOTE: see [`getByLabelText`](#getbylabeltext) for more details on how and when to use the `selector` option
+
+The `ignore` option accepts a query selector. If the
+[`node.matches`](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches)
+returns true for that selector, the node will be ignored. This defaults to
+`'script'` because generally you don't want to select script tags, but if your
+content is in an inline script file, then the script tag could be returned.
+
+If you'd rather disable this behavior, set `ignore` to `false`.
 
 ### `getByAltText`
 

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -512,4 +512,12 @@ test('get throws a useful error message without DOM in Cypress', () => {
   expect(() => getByValue('LucyRicardo')).toThrowErrorMatchingSnapshot()
 })
 
+test('getByText ignores script tags by default', () => {
+  const {getAllByText} = render('<script>Hello</script><div>Hello</div>')
+  const divOnly = getAllByText(/hello/i)
+  expect(divOnly).toHaveLength(1)
+  expect(divOnly[0].tagName).toBe('DIV')
+  expect(getAllByText(/hello/i, {ignore: false})).toHaveLength(2)
+})
+
 /* eslint jsx-a11y/label-has-for:0 */

--- a/src/queries.js
+++ b/src/queries.js
@@ -69,13 +69,19 @@ function queryByLabelText(...args) {
 function queryAllByText(
   container,
   text,
-  {selector = '*', exact = true, collapseWhitespace = true, trim = true} = {},
+  {
+    selector = '*',
+    exact = true,
+    collapseWhitespace = true,
+    trim = true,
+    ignore = 'script',
+  } = {},
 ) {
   const matcher = exact ? matches : fuzzyMatches
   const matchOpts = {collapseWhitespace, trim}
-  return Array.from(container.querySelectorAll(selector)).filter(node =>
-    matcher(getNodeText(node), node, text, matchOpts),
-  )
+  return Array.from(container.querySelectorAll(selector))
+    .filter(node => !ignore || !node.matches(ignore))
+    .filter(node => matcher(getNodeText(node), node, text, matchOpts))
 }
 
 function queryByText(...args) {


### PR DESCRIPTION
**What**: add `ignore` option to `*ByText` which defaults to `'script'`

**Why**:

In our app at PayPal we're testing with Cypress and our localization content is set in a script tag on the page when it's rendered by the server. When using `getByText` with `cypress-testing-library`, we were getting that script tag before the app had a chance to render.

I'm pretty confident that 99.999% of the time people wont want to get a script tag with `getByText`, so the default makes sense to me.

**How**:

Added another layer of filtering to `queryAllByText` to filter nodes which return true for `.matches(ignore)`. Feel pretty flexible. Happy that DOM API exists!

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A

<!-- feel free to add additional comments -->
