### PR TITLE
Make event functions accept Element

### DIFF
--- a/typings/events.d.ts
+++ b/typings/events.d.ts
@@ -69,9 +69,9 @@ export type EventType =
   | 'transitionEnd'
   | 'doubleClick'
 
-export type FireFunction = (element: HTMLElement, event: Event) => boolean
+export type FireFunction = (element: Element, event: Event) => boolean
 export type FireObject = {
-  [K in EventType]: (element: HTMLElement, options?: {}) => boolean
+  [K in EventType]: (element: Element, options?: {}) => boolean
 }
 
 export const fireEvent: FireFunction & FireObject


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Update typescript types to allow for `Element` (instead of `HTMLElement`) to be used in event functions.

<!-- Why are these changes necessary? -->

**Why**: Browser APIs such as `querySelector` returns `Element`, not `HTMLElement`. This requires an explicit cast to use the event functions from `dom-testing-library`.

<!-- How were these changes implemented? -->

**How**: Updated typescript definitions.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
Resolves #149