### PR TITLE
fix(waitForDomChange): fix link to TS types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,6 +9,7 @@ export {queries, queryHelpers, within}
 export * from './queries'
 export * from './query-helpers'
 export * from './wait'
+export * from './wait-for-dom-change'
 export * from './wait-for-element'
 export * from './matches'
 export * from './get-node-text'


### PR DESCRIPTION
**What**:

TypeScript typings were added for `waitForDomChange` in #117 but were never linked to from index.d.ts.

**Why**:

Without this change, `waitForDomChange` isn't accessible from TypeScript code, and the TS typings for the function are wasted.

**Checklist**:

- [x] Documentation (N/A)
- [x] Tests (N/A)
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
