### PR TITLE
fix(TS): add focusin/focusout typings

### DIFF
--- a/typings/events.d.ts
+++ b/typings/events.d.ts
@@ -10,6 +10,8 @@ export type EventType =
   | 'keyUp'
   | 'focus'
   | 'blur'
+  | 'focusIn'
+  | 'focusOut'
   | 'change'
   | 'input'
   | 'invalid'


### PR DESCRIPTION
**What**:
Add typings for the new focusin/focusout events

**Why**:

Enables the new API to be used from TypeScript

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
