### PR TITLE
Make getByText support inputs where type is either `button` or `submit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,14 @@ matching the given [`TextMatch`](#textmatch).
 const aboutAnchorNode = getByText(container, /about/i)
 ```
 
+It also works properly with `input`s whose `type` attribute is either `submit`
+or `button`:
+
+```javascript
+// <input type="submit" value="Send data" />
+const submitButton = getByText(container, /send data/i)
+```
+
 > NOTE: see [`getByLabelText`](#getbylabeltext) for more details on how and when to use the `selector` option
 
 The `ignore` option accepts a query selector. If the
@@ -701,6 +709,17 @@ const text = getNodeText(container.querySelector('div')) // "Hello World !"
 This function is also used internally when querying nodes by their text content.
 This enables functions like `getByText` and `queryByText` to work as expected,
 finding elements in the DOM similarly to how users would do.
+
+The function has a special behavior for some input elements:
+
+```javascript
+// <input type="submit" value="Send data" />
+// <input type="button" value="Push me" />
+const submitText = getNodeText(container.querySelector('input[type=submit]')) // "Send data"
+const buttonText = getNodeText(container.querySelector('input[type=button]')) // "Push me"
+
+These elements use the attribute `value` and display its value to the user.
+```
 
 ## Custom Jest Matchers
 

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -76,6 +76,19 @@ test('can get elements by matching their text across adjacent text nodes', () =>
   expect(queryByText('£24.99')).toBeTruthy()
 })
 
+test('can get input elements with type submit or button', () => {
+  const {queryByText} = render(`
+    <div>
+      <input type="submit" value="Send data"/>
+      <input type="button" value="Push me!"/>
+      <input type="text" value="user data" />
+    </div>
+  `)
+  expect(queryByText('Send data')).toBeTruthy()
+  expect(queryByText('Push me!')).toBeTruthy()
+  expect(queryByText('user data')).toBeFalsy()
+})
+
 test('matches case with RegExp matcher', () => {
   const {queryByText} = render(`
     <span>STEP 1 of 4</span>

--- a/src/get-node-text.js
+++ b/src/get-node-text.js
@@ -1,6 +1,10 @@
 function getNodeText(node) {
   const window = node.ownerDocument.defaultView
 
+  if (node.matches("input[type=submit], input[type=button]")) {
+    return node.value;
+  }
+
   return Array.from(node.childNodes)
     .filter(
       child =>


### PR DESCRIPTION
Fixes kentcdodds/react-testing-library#248


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
