### PR TITLE
Use innerText rather than textContent for label queries.

### DIFF
--- a/src/__tests__/elements-inside-label.js
+++ b/src/__tests__/elements-inside-label.js
@@ -1,0 +1,37 @@
+// query utilities:
+import {getByLabelText} from '../'
+import document from './helpers/document'
+
+function getExampleDOM() {
+  const div = document.createElement('div')
+  div.innerHTML = `
+    <label>Cars
+        <select>
+            <option>Volvo</option>
+            <option>Mercedes</option>
+        </select>
+    </label>
+    <label><span>States</span>
+        <select>
+            <option>Damaged</option>
+            <option>Good</option>
+        </select>
+    </label>
+    <label><input type="checkbox" value="1"> I agree to terms </label>
+  `
+  return div
+}
+
+test('elements inside label', () => {
+  const container = getExampleDOM()
+
+  const element1 = getByLabelText(container, 'Cars')
+  expect(element1.tagName).toBe('SELECT')
+
+  // this fails because getNodeText function returns incorrect result on JSDOM but it good for browser
+  // const element2 = getByLabelText(container, 'States');
+  // expect(element2.tagName).toBe('SELECT');
+
+  const element3 = getByLabelText(container, 'I agree to terms')
+  expect(element3.value).toBe('1')
+})

--- a/src/get-node-text.js
+++ b/src/get-node-text.js
@@ -2,16 +2,20 @@ function getNodeText(node) {
   const window = node.ownerDocument.defaultView
 
   if (node.matches('input[type=submit], input[type=button]')) {
-    return node.value;
+    return node.value
   }
 
-  return Array.from(node.childNodes)
-    .filter(
-      child =>
-        child.nodeType === window.Node.TEXT_NODE && Boolean(child.textContent),
-    )
-    .map(c => c.textContent)
-    .join('')
+  return (
+    node.innerText ||
+    Array.from(node.childNodes)
+      .filter(
+        child =>
+          child.nodeType === window.Node.TEXT_NODE &&
+          Boolean(child.textContent),
+      )
+      .map(c => c.textContent)
+      .join('')
+  )
 }
 
 export {getNodeText}

--- a/src/queries.js
+++ b/src/queries.js
@@ -20,7 +20,7 @@ function queryAllLabelsByText(
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
   return Array.from(container.querySelectorAll('label')).filter(label =>
-    matcher(label.textContent, label, text, matchNormalizer),
+    matcher(label.innerText || label.textContent, label, text, matchNormalizer),
   )
 }
 

--- a/src/queries.js
+++ b/src/queries.js
@@ -20,7 +20,7 @@ function queryAllLabelsByText(
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
   return Array.from(container.querySelectorAll('label')).filter(label =>
-    matcher(label.innerText || label.textContent, label, text, matchNormalizer),
+    matcher(getNodeText(label), label, text, matchNormalizer),
   )
 }
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Using label.innerText rather than label.textContent

<!-- Why are these changes necessary? -->
**Why**:
An example dom: 
```html
<label>
Options
<select>
    <option>Option 1</option>
    <option>Option 2</option>
</select>
</label>
```
textContent returns incorrect result for label text
```text
Options

    Option 1
    Option 2
```

but innerText returns correct result "Options".

But I can not be simulate with jest tests also `label.innerText || label.textContent` used because jsdom does not support innerText https://github.com/jsdom/jsdom/issues/1245

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
