### PR TITLE
Fix node.matches is not a function

### DIFF
--- a/src/queries.js
+++ b/src/queries.js
@@ -109,7 +109,7 @@ function queryAllByText(
   if (typeof container.matches === 'function' && container.matches(selector)) {
     baseArray = [container]
   }
-  return Array.from([...baseArray, ...Array.from(container.querySelectorAll(selector))])
+  return [...baseArray, ...Array.from(container.querySelectorAll(selector))]
     .filter(node => !ignore || !node.matches(ignore))
     .filter(node => matcher(getNodeText(node), node, text, matchNormalizer))
 }

--- a/src/queries.js
+++ b/src/queries.js
@@ -109,7 +109,7 @@ function queryAllByText(
   if (typeof container.matches === 'function' && container.matches(selector)) {
     baseArray = [container]
   }
-  return Array.from([...baseArray, ...container.querySelectorAll(selector)])
+  return Array.from([...baseArray, ...Array.from(container.querySelectorAll(selector))])
     .filter(node => !ignore || !node.matches(ignore))
     .filter(node => matcher(getNodeText(node), node, text, matchNormalizer))
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Fixes https://github.com/kentcdodds/dom-testing-library/issues/215

**What**:

<!-- Why are these changes necessary? -->

Fixes the error caused by loose mode transpilation as spotted by @lavigneer:

> No, there aren't any elements in that `NodeList` that are also a `NodeList`
> 
> I just tested wrapping `container.querySelectorAll(selector)` explicitly in an `Array.from` call in the built `.esm` bundle and that appeared to resolve the issue.
> 
> The transpilation of
> `Array.from([...baseArray, ...container.querySelectorAll(selector)])`
> results in
> `Array.from([].concat(baseArray, container.querySelectorAll(selector)))`
> so it's not converting the `NodeList` to an array and is just trying to `concat` it directly



**Why**:

To fix regression

<!-- How were these changes implemented? -->

**How**:

Explicitly use `Array.from` to force the `NodeList` to be converted to an array and spread correctly.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
-  Typescript definitions updated N/A
- Tests N/A can't be tested as bug is in transpilation
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
