### PR TITLE
fix(ByLabel): use getNodeText abstraction instead of textContent

### DIFF
--- a/src/get-node-text.js
+++ b/src/get-node-text.js
@@ -2,7 +2,7 @@ function getNodeText(node) {
   const window = node.ownerDocument.defaultView
 
   if (node.matches('input[type=submit], input[type=button]')) {
-    return node.value;
+    return node.value
   }
 
   return Array.from(node.childNodes)

--- a/src/queries.js
+++ b/src/queries.js
@@ -21,7 +21,7 @@ function queryAllLabelsByText(
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
   return Array.from(container.querySelectorAll('label')).filter(label =>
-    matcher(label.textContent, label, text, matchNormalizer),
+    matcher(getNodeText(label), label, text, matchNormalizer),
   )
 }
 

--- a/src/wait-for-element.js
+++ b/src/wait-for-element.js
@@ -22,7 +22,7 @@ function waitForElement(
     const observer = newMutationObserver(onMutation)
     observer.observe(container, mutationObserverOptions)
     function onDone(error, result) {
-      const setImmediate = getSetImmediate();
+      const setImmediate = getSetImmediate()
       clearTimeout(timer)
       setImmediate(() => observer.disconnect())
       if (error) {

--- a/typings/get-queries-for-element.d.ts
+++ b/typings/get-queries-for-element.d.ts
@@ -9,8 +9,8 @@ export type BoundFunction<T> = T extends (
 ) => infer R
   ? (text: P, options?: Q) => R
   : T extends (a1: any, text: infer P, options: infer Q) => infer R
-    ? (text: P, options?: Q) => R
-    : never
+  ? (text: P, options?: Q) => R
+  : never
 export type BoundFunctions<T> = {[P in keyof T]: BoundFunction<T[P]>}
 
 export function getQueriesForElement(


### PR DESCRIPTION
**What**: fix(ByLabel): use getNodeText abstraction instead of textContent

**Why**: Closes #190

**How**: Make `queryAllByLabelText` use `getNodeText` instead of `textContent`

Also, I formatted everything 🤷‍♂️ 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [ ] Typescript definitions updated N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
