### PR TITLE
fix: remove deprecated queries

### DIFF
--- a/src/__tests__/__snapshots__/element-queries.js.snap
+++ b/src/__tests__/__snapshots__/element-queries.js.snap
@@ -9,7 +9,7 @@ exports[`get throws a useful error message 1`] = `
 `;
 
 exports[`get throws a useful error message 2`] = `
-"Unable to find a <select> element with the selected option's text: LucyRicardo
+"Unable to find an element with the value: LucyRicardo.
 
 [36m<div>[39m
   [36m<div />[39m
@@ -74,7 +74,7 @@ exports[`get throws a useful error message 9`] = `
 
 exports[`get throws a useful error message without DOM in Cypress 1`] = `"Unable to find a label with the text of: LucyRicardo"`;
 
-exports[`get throws a useful error message without DOM in Cypress 2`] = `"Unable to find a <select> element with the selected option's text: LucyRicardo"`;
+exports[`get throws a useful error message without DOM in Cypress 2`] = `"Unable to find an element with the value: LucyRicardo."`;
 
 exports[`get throws a useful error message without DOM in Cypress 3`] = `"Unable to find an element with the placeholder text of: LucyRicardo"`;
 

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -8,7 +8,7 @@ beforeEach(() => {
 test('query can return null', () => {
   const {
     queryByLabelText,
-    queryBySelectText,
+    queryByDisplayValue,
     queryByPlaceholderText,
     queryByText,
     queryByTestId,
@@ -16,7 +16,7 @@ test('query can return null', () => {
   } = render('<div />')
   expect(queryByTestId('LucyRicardo')).toBeNull()
   expect(queryByLabelText('LucyRicardo')).toBeNull()
-  expect(queryBySelectText('LucyRicardo')).toBeNull()
+  expect(queryByDisplayValue('LucyRicardo')).toBeNull()
   expect(queryByPlaceholderText('LucyRicardo')).toBeNull()
   expect(queryByText('LucyRicardo')).toBeNull()
   expect(queryByAltText('LucyRicardo')).toBeNull()
@@ -25,17 +25,16 @@ test('query can return null', () => {
 test('get throws a useful error message', () => {
   const {
     getByLabelText,
-    getBySelectText,
+    getByDisplayValue,
     getByPlaceholderText,
     getByText,
     getByTestId,
     getByAltText,
     getByTitle,
-    getByValue,
     getByRole,
   } = render('<div />')
   expect(() => getByLabelText('LucyRicardo')).toThrowErrorMatchingSnapshot()
-  expect(() => getBySelectText('LucyRicardo')).toThrowErrorMatchingSnapshot()
+  expect(() => getByDisplayValue('LucyRicardo')).toThrowErrorMatchingSnapshot()
   expect(() =>
     getByPlaceholderText('LucyRicardo'),
   ).toThrowErrorMatchingSnapshot()
@@ -43,7 +42,7 @@ test('get throws a useful error message', () => {
   expect(() => getByTestId('LucyRicardo')).toThrowErrorMatchingSnapshot()
   expect(() => getByAltText('LucyRicardo')).toThrowErrorMatchingSnapshot()
   expect(() => getByTitle('LucyRicardo')).toThrowErrorMatchingSnapshot()
-  expect(() => getByValue('LucyRicardo')).toThrowErrorMatchingSnapshot()
+  expect(() => getByDisplayValue('LucyRicardo')).toThrowErrorMatchingSnapshot()
   expect(() => getByRole('LucyRicardo')).toThrowErrorMatchingSnapshot()
 })
 
@@ -216,7 +215,7 @@ test('query/get title element of SVG', () => {
 })
 
 test('query/get element by its value', () => {
-  const {getByValue, queryByValue} = render(`
+  const {getByDisplayValue, queryByDisplayValue} = render(`
   <div>
     <input placeholder="name" type="text"/>
     <input placeholder="lastname" type="text" value="Norris"/>
@@ -224,12 +223,12 @@ test('query/get element by its value', () => {
   </div>
   `)
 
-  expect(getByValue('Norris').placeholder).toEqual('lastname')
-  expect(queryByValue('Norris').placeholder).toEqual('lastname')
+  expect(getByDisplayValue('Norris').placeholder).toEqual('lastname')
+  expect(queryByDisplayValue('Norris').placeholder).toEqual('lastname')
 })
 
 test('query/get select by text with the default option selected', () => {
-  const {getBySelectText, queryBySelectText} = render(`
+  const {getByDisplayValue, queryByDisplayValue} = render(`
   <select id="state-select">
     <option value="">State</option>
     <option value="AL">Alabama</option>
@@ -238,12 +237,12 @@ test('query/get select by text with the default option selected', () => {
   </select>
   `)
 
-  expect(getBySelectText('State').id).toEqual('state-select')
-  expect(queryBySelectText('State').id).toEqual('state-select')
+  expect(getByDisplayValue('State').id).toEqual('state-select')
+  expect(queryByDisplayValue('State').id).toEqual('state-select')
 })
 
 test('query/get select by text with one option selected', () => {
-  const {getBySelectText, queryBySelectText} = render(`
+  const {getByDisplayValue, queryByDisplayValue} = render(`
   <select id="state-select">
     <option value="">State</option>
     <option value="AL">Alabama</option>
@@ -252,12 +251,12 @@ test('query/get select by text with one option selected', () => {
   </select>
   `)
 
-  expect(getBySelectText('Alaska').id).toEqual('state-select')
-  expect(queryBySelectText('Alaska').id).toEqual('state-select')
+  expect(getByDisplayValue('Alaska').id).toEqual('state-select')
+  expect(queryByDisplayValue('Alaska').id).toEqual('state-select')
 })
 
 test('query/get select by text with multiple options selected', () => {
-  const {getBySelectText, queryBySelectText} = render(`
+  const {getByDisplayValue, queryByDisplayValue} = render(`
   <select multiple id="state-select">
     <option value="">State</option>
     <option selected value="AL">Alabama</option>
@@ -266,8 +265,8 @@ test('query/get select by text with multiple options selected', () => {
   </select>
   `)
 
-  expect(getBySelectText('Alabama').id).toEqual('state-select')
-  expect(queryBySelectText('Alaska').id).toEqual('state-select')
+  expect(getByDisplayValue('Alabama').id).toEqual('state-select')
+  expect(queryByDisplayValue('Alaska').id).toEqual('state-select')
 })
 
 describe('query by test id', () => {
@@ -305,7 +304,7 @@ test('getAll* matchers return an array', () => {
     getAllByAltText,
     getAllByTestId,
     getAllByLabelText,
-    getAllBySelectText,
+    getAllByDisplayValue,
     getAllByPlaceholderText,
     getAllByText,
     getAllByRole,
@@ -343,8 +342,8 @@ test('getAll* matchers return an array', () => {
   expect(getAllByTestId('poster')).toHaveLength(3)
   expect(getAllByPlaceholderText(/The Rock/)).toHaveLength(1)
   expect(getAllByLabelText('User Name')).toHaveLength(1)
-  expect(getAllBySelectText('Japanese cars')).toHaveLength(1)
-  expect(getAllBySelectText(/cars$/)).toHaveLength(2)
+  expect(getAllByDisplayValue('Japanese cars')).toHaveLength(1)
+  expect(getAllByDisplayValue(/cars$/)).toHaveLength(2)
   expect(getAllByText(/^where/i)).toHaveLength(1)
   expect(getAllByRole(/container/i)).toHaveLength(1)
 })
@@ -354,11 +353,10 @@ test('getAll* matchers throw for 0 matches', () => {
     getAllByAltText,
     getAllByTestId,
     getAllByLabelText,
-    getAllBySelectText,
+    getAllByDisplayValue,
     getAllByPlaceholderText,
     getAllByText,
     getAllByRole,
-    getAllByDisplayValue,
   } = render(`
     <div role="container">
       <label>No Matches Please</label>
@@ -369,7 +367,7 @@ test('getAll* matchers throw for 0 matches', () => {
   expect(() => getAllByAltText('nope')).toThrow()
   expect(() => getAllByLabelText('nope')).toThrow()
   expect(() => getAllByLabelText('no matches please')).toThrow()
-  expect(() => getAllBySelectText('nope')).toThrow()
+  expect(() => getAllByDisplayValue('nope')).toThrow()
   expect(() => getAllByPlaceholderText('nope')).toThrow()
   expect(() => getAllByText('nope')).toThrow()
   expect(() => getAllByRole('nope')).toThrow()
@@ -381,7 +379,7 @@ test('queryAll* matchers return an array for 0 matches', () => {
     queryAllByAltText,
     queryAllByTestId,
     queryAllByLabelText,
-    queryAllBySelectText,
+    queryAllByDisplayValue,
     queryAllByPlaceholderText,
     queryAllByText,
     queryAllByRole,
@@ -392,7 +390,7 @@ test('queryAll* matchers return an array for 0 matches', () => {
   expect(queryAllByTestId('nope')).toHaveLength(0)
   expect(queryAllByAltText('nope')).toHaveLength(0)
   expect(queryAllByLabelText('nope')).toHaveLength(0)
-  expect(queryAllBySelectText('nope')).toHaveLength(0)
+  expect(queryAllByDisplayValue('nope')).toHaveLength(0)
   expect(queryAllByPlaceholderText('nope')).toHaveLength(0)
   expect(queryAllByText('nope')).toHaveLength(0)
   expect(queryAllByRole('nope')).toHaveLength(0)
@@ -560,16 +558,15 @@ test('get throws a useful error message without DOM in Cypress', () => {
   document.defaultView.Cypress = {}
   const {
     getByLabelText,
-    getBySelectText,
     getByPlaceholderText,
     getByText,
     getByTestId,
     getByAltText,
     getByTitle,
-    getByValue,
+    getByDisplayValue,
   } = render('<div />')
   expect(() => getByLabelText('LucyRicardo')).toThrowErrorMatchingSnapshot()
-  expect(() => getBySelectText('LucyRicardo')).toThrowErrorMatchingSnapshot()
+  expect(() => getByDisplayValue('LucyRicardo')).toThrowErrorMatchingSnapshot()
   expect(() =>
     getByPlaceholderText('LucyRicardo'),
   ).toThrowErrorMatchingSnapshot()
@@ -577,7 +574,7 @@ test('get throws a useful error message without DOM in Cypress', () => {
   expect(() => getByTestId('LucyRicardo')).toThrowErrorMatchingSnapshot()
   expect(() => getByAltText('LucyRicardo')).toThrowErrorMatchingSnapshot()
   expect(() => getByTitle('LucyRicardo')).toThrowErrorMatchingSnapshot()
-  expect(() => getByValue('LucyRicardo')).toThrowErrorMatchingSnapshot()
+  expect(() => getByDisplayValue('LucyRicardo')).toThrowErrorMatchingSnapshot()
 })
 
 test('getByText ignores script tags by default', () => {

--- a/src/__tests__/text-matchers.js
+++ b/src/__tests__/text-matchers.js
@@ -39,14 +39,14 @@ cases(
       query: `Dwayne 'The Rock' Johnson`,
       queryFn: `queryAllByPlaceholderText`,
     },
-    queryAllBySelectText: {
+    'queryAllByDisplayValue (for select)': {
       dom: `
       <select>
         <option>Option 1</option>
         <option>Option 2</option>
       </select>`,
       query: `Option 1`,
-      queryFn: `queryAllBySelectText`,
+      queryFn: `queryAllByDisplayValue`,
     },
     queryAllByText: {
       dom: `<p>Some content</p>`,
@@ -99,14 +99,14 @@ cases(
       query: /^Dwayne/,
       queryFn: `queryAllByPlaceholderText`,
     },
-    queryAllBySelectText: {
+    'queryAllByDisplayValue (for select)': {
       dom: `
       <select>
         <option>  Option 1  </option>
         <option>Option 2</option>
       </select>`,
       query: `Option 1`,
-      queryFn: `queryAllBySelectText`,
+      queryFn: `queryAllByDisplayValue`,
     },
     queryAllByText: {
       dom: `
@@ -161,14 +161,14 @@ cases(
       query: `Dwayne 'The Rock' Johnson`,
       queryFn: `queryAllByPlaceholderText`,
     },
-    queryAllBySelectText: {
+    'queryAllByDisplayValue (for select)': {
       dom: `
       <select>
         <option>Option 1</option>
         <option>Option 2</option>
       </select>`,
       query: `Option 1`,
-      queryFn: `queryAllBySelectText`,
+      queryFn: `queryAllByDisplayValue`,
     },
     queryAllByLabelText: {
       dom: `
@@ -235,9 +235,9 @@ cases(
       dom: `<input placeholder="User ${LRM}name" />`,
       queryFn: 'queryAllByPlaceholderText',
     },
-    queryAllBySelectText: {
+    'queryAllByDisplayValue (for select)': {
       dom: `<select><option>User ${LRM}name</option></select>`,
-      queryFn: 'queryAllBySelectText',
+      queryFn: 'queryAllByDisplayValue',
     },
     queryAllByText: {
       dom: `<div>User ${LRM}name</div>`,
@@ -250,10 +250,6 @@ cases(
     queryAllByTitle: {
       dom: `<div title="User ${LRM}name" />`,
       queryFn: 'queryAllByTitle',
-    },
-    queryAllByValue: {
-      dom: `<input value="User ${LRM}name" />`,
-      queryFn: 'queryAllByValue',
     },
     queryAllByDisplayValue: {
       dom: `<input value="User ${LRM}name" />`,

--- a/src/queries.js
+++ b/src/queries.js
@@ -137,27 +137,6 @@ function queryByTitle(...args) {
   return firstResultOrNull(queryAllByTitle, ...args)
 }
 
-function queryAllBySelectText(
-  container,
-  text,
-  {exact = true, collapseWhitespace, trim, normalizer} = {},
-) {
-  const matcher = exact ? matches : fuzzyMatches
-  const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
-  return Array.from(container.querySelectorAll('select')).filter(selectNode => {
-    const selectedOptions = Array.from(selectNode.options).filter(
-      option => option.selected,
-    )
-    return selectedOptions.some(optionNode =>
-      matcher(getNodeText(optionNode), optionNode, text, matchNormalizer),
-    )
-  })
-}
-
-function queryBySelectText(...args) {
-  return firstResultOrNull(queryAllBySelectText, ...args)
-}
-
 function getTestIdAttribute() {
   return getConfig().testIdAttribute
 }
@@ -168,8 +147,6 @@ const queryByTestId = (...args) =>
   queryByAttribute(getTestIdAttribute(), ...args)
 const queryAllByTestId = (...args) =>
   queryAllByAttribute(getTestIdAttribute(), ...args)
-const queryByValue = queryByAttribute.bind(null, 'value')
-const queryAllByValue = queryAllByAttribute.bind(null, 'value')
 const queryByRole = queryByAttribute.bind(null, 'role')
 const queryAllByRole = queryAllByAttribute.bind(null, 'role')
 
@@ -249,21 +226,6 @@ function getAllByTitle(container, title, ...rest) {
 
 function getByTitle(...args) {
   return firstResultOrNull(getAllByTitle, ...args)
-}
-
-function getAllByValue(container, value, ...rest) {
-  const els = queryAllByValue(container, value, ...rest)
-  if (!els.length) {
-    throw getElementError(
-      `Unable to find an element with the value: ${value}.`,
-      container,
-    )
-  }
-  return els
-}
-
-function getByValue(...args) {
-  return firstResultOrNull(getAllByValue, ...args)
 }
 
 function getAllByPlaceholderText(container, text, ...rest) {
@@ -346,21 +308,6 @@ function getByRole(...args) {
   return firstResultOrNull(getAllByRole, ...args)
 }
 
-function getAllBySelectText(container, text, ...rest) {
-  const els = queryAllBySelectText(container, text, ...rest)
-  if (!els.length) {
-    throw getElementError(
-      `Unable to find a <select> element with the selected option's text: ${text}`,
-      container,
-    )
-  }
-  return els
-}
-
-function getBySelectText(...args) {
-  return firstResultOrNull(getAllBySelectText, ...args)
-}
-
 function getAllByDisplayValue(container, value, ...rest) {
   const els = queryAllByDisplayValue(container, value, ...rest)
   if (!els.length) {
@@ -425,10 +372,6 @@ export {
   queryAllByAltText,
   getByAltText,
   getAllByAltText,
-  queryBySelectText,
-  queryAllBySelectText,
-  getBySelectText,
-  getAllBySelectText,
   queryByTestId,
   queryAllByTestId,
   getByTestId,
@@ -437,10 +380,6 @@ export {
   queryAllByTitle,
   getByTitle,
   getAllByTitle,
-  queryByValue,
-  queryAllByValue,
-  getByValue,
-  getAllByValue,
   queryByDisplayValue,
   queryAllByDisplayValue,
   getByDisplayValue,

--- a/typings/queries.d.ts
+++ b/typings/queries.d.ts
@@ -41,10 +41,6 @@ export const queryByPlaceholderText: QueryByBoundAttribute
 export const queryAllByPlaceholderText: AllByBoundAttribute
 export const getByPlaceholderText: GetByBoundAttribute
 export const getAllByPlaceholderText: AllByBoundAttribute
-export const queryBySelectText: QueryByBoundAttribute
-export const queryAllBySelectText: AllByBoundAttribute
-export const getBySelectText: GetByBoundAttribute
-export const getAllBySelectText: AllByBoundAttribute
 export const queryByText: QueryByText
 export const queryAllByText: AllByText
 export const getByText: GetByText
@@ -65,10 +61,6 @@ export const queryByTitle: QueryByBoundAttribute
 export const queryAllByTitle: AllByBoundAttribute
 export const getByTitle: GetByBoundAttribute
 export const getAllByTitle: AllByBoundAttribute
-export const queryByValue: QueryByBoundAttribute
-export const queryAllByValue: AllByBoundAttribute
-export const getByValue: GetByBoundAttribute
-export const getAllByValue: AllByBoundAttribute
 export const queryByDisplayValue: QueryByBoundAttribute
 export const queryAllByDisplayValue: AllByBoundAttribute
 export const getByDisplayValue: GetByBoundAttribute


### PR DESCRIPTION
**What**: fix: remove deprecated queries

<!-- Why are these changes necessary? -->

**Why**: Closes #223

<!-- How were these changes implemented? -->

**How**: Removed the queries and updated tests for those old queries to use the newer `ByDisplayValue` variant.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [x] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->


BREAKING CHANGE: This removes the deprecated queries `ByValue` and `BySelectText`. Use `ByDisplayValue` instead.
