### PR TITLE
Pr/issue 226 findby type definitions

### DIFF
--- a/typings/queries.d.ts
+++ b/typings/queries.d.ts
@@ -17,7 +17,7 @@ export type FindAllByBoundAttribute = (
   container: HTMLElement,
   id: Matcher,
   options?: MatcherOptions,
-) => Promise<HTMLElement[]>
+) => Promise<HTMLElement[]> | Error
 
 export type GetByBoundAttribute = (
   container: HTMLElement,
@@ -29,7 +29,7 @@ export type FindByBoundAttribute = (
   container: HTMLElement,
   id: Matcher,
   options?: MatcherOptions,
-) => Promise<HTMLElement>
+) => Promise<HTMLElement> | Error
 
 export type QueryByText = (
   container: HTMLElement,
@@ -47,7 +47,7 @@ export type FindAllByText = (
   container: HTMLElement,
   id: Matcher,
   options?: SelectorMatcherOptions,
-) => Promise<HTMLElement[]>
+) => Promise<HTMLElement[]> | Error
 
 export type GetByText = (
   container: HTMLElement,
@@ -59,7 +59,7 @@ export type FindByText = (
   container: HTMLElement,
   id: Matcher,
   options?: SelectorMatcherOptions,
-) => Promise<HTMLElement>
+) => Promise<HTMLElement> | Error
 
 export const getByLabelText: GetByText
 export const getAllByLabelText: AllByText

--- a/typings/queries.d.ts
+++ b/typings/queries.d.ts
@@ -1,5 +1,6 @@
 import {Matcher, MatcherOptions} from './matches'
 import {SelectorMatcherOptions} from './query-helpers'
+import {WaitForElementOptions} from './wait-for-element'
 
 export type QueryByBoundAttribute = (
   container: HTMLElement,
@@ -17,6 +18,7 @@ export type FindAllByBoundAttribute = (
   container: HTMLElement,
   id: Matcher,
   options?: MatcherOptions,
+  waitForElementOptions?: WaitForElementOptions
 ) => Promise<HTMLElement[]> | Error
 
 export type GetByBoundAttribute = (
@@ -29,6 +31,7 @@ export type FindByBoundAttribute = (
   container: HTMLElement,
   id: Matcher,
   options?: MatcherOptions,
+  waitForElementOptions?: WaitForElementOptions
 ) => Promise<HTMLElement> | Error
 
 export type QueryByText = (
@@ -47,6 +50,7 @@ export type FindAllByText = (
   container: HTMLElement,
   id: Matcher,
   options?: SelectorMatcherOptions,
+  waitForElementOptions?: WaitForElementOptions
 ) => Promise<HTMLElement[]> | Error
 
 export type GetByText = (
@@ -59,6 +63,7 @@ export type FindByText = (
   container: HTMLElement,
   id: Matcher,
   options?: SelectorMatcherOptions,
+  waitForElementOptions?: WaitForElementOptions
 ) => Promise<HTMLElement> | Error
 
 export const getByLabelText: GetByText

--- a/typings/queries.d.ts
+++ b/typings/queries.d.ts
@@ -1,5 +1,5 @@
-import {Matcher, MatcherOptions} from './matches'
-import {SelectorMatcherOptions} from './query-helpers'
+import { Matcher, MatcherOptions } from './matches'
+import { SelectorMatcherOptions } from './query-helpers'
 
 export type QueryByBoundAttribute = (
   container: HTMLElement,
@@ -13,11 +13,23 @@ export type AllByBoundAttribute = (
   options?: MatcherOptions,
 ) => HTMLElement[]
 
+export type FindAllByBoundAttribute = (
+  container: HTMLElement,
+  id: Matcher,
+  options?: MatcherOptions,
+) => Promise<HTMLElement[]>
+
 export type GetByBoundAttribute = (
   container: HTMLElement,
   id: Matcher,
   options?: MatcherOptions,
 ) => HTMLElement
+
+export type FindByBoundAttribute = (
+  container: HTMLElement,
+  id: Matcher,
+  options?: MatcherOptions,
+) => Promise<HTMLElement>
 
 export type QueryByText = (
   container: HTMLElement,
@@ -31,49 +43,81 @@ export type AllByText = (
   options?: SelectorMatcherOptions,
 ) => HTMLElement[]
 
+export type FindAllByText = (
+  container: HTMLElement,
+  id: Matcher,
+  options?: SelectorMatcherOptions,
+) => Promise<HTMLElement[]>
+
 export type GetByText = (
   container: HTMLElement,
   id: Matcher,
   options?: SelectorMatcherOptions,
 ) => HTMLElement
 
-export const queryByPlaceholderText: QueryByBoundAttribute
-export const queryAllByPlaceholderText: AllByBoundAttribute
-export const getByPlaceholderText: GetByBoundAttribute
-export const getAllByPlaceholderText: AllByBoundAttribute
-export const queryBySelectText: QueryByBoundAttribute
-export const queryAllBySelectText: AllByBoundAttribute
-export const getBySelectText: GetByBoundAttribute
-export const getAllBySelectText: AllByBoundAttribute
-export const queryByText: QueryByText
-export const queryAllByText: AllByText
-export const getByText: GetByText
-export const getAllByText: AllByText
-export const queryByLabelText: QueryByText
-export const queryAllByLabelText: AllByText
+export type FindByText = (
+  container: HTMLElement,
+  id: Matcher,
+  options?: SelectorMatcherOptions,
+) => Promise<HTMLElement>
+
 export const getByLabelText: GetByText
 export const getAllByLabelText: AllByText
-export const queryByAltText: QueryByBoundAttribute
-export const queryAllByAltText: AllByBoundAttribute
+export const queryByLabelText: QueryByText
+export const queryAllByLabelText: AllByText
+export const findByLabelText: FindByText
+export const findAllByLabelText: FindAllByText
+export const getByPlaceholderText: GetByBoundAttribute
+export const getAllByPlaceholderText: AllByBoundAttribute
+export const queryByPlaceholderText: QueryByBoundAttribute
+export const queryAllByPlaceholderText: AllByBoundAttribute
+export const findByPlaceholderText: FindByBoundAttribute
+export const findAllByPlaceholderText: FindAllByBoundAttribute
+export const getByText: GetByText
+export const getAllByText: AllByText
+export const queryByText: QueryByText
+export const queryAllByText: AllByText
+export const findByText: FindByText
+export const findAllByText: FindAllByText
 export const getByAltText: GetByBoundAttribute
 export const getAllByAltText: AllByBoundAttribute
-export const queryByTestId: QueryByBoundAttribute
-export const queryAllByTestId: AllByBoundAttribute
-export const getByTestId: GetByBoundAttribute
-export const getAllByTestId: AllByBoundAttribute
-export const queryByTitle: QueryByBoundAttribute
-export const queryAllByTitle: AllByBoundAttribute
+export const queryByAltText: QueryByBoundAttribute
+export const queryAllByAltText: AllByBoundAttribute
+export const findByAltText: FindByBoundAttribute
+export const findAllByAltText: FindAllByBoundAttribute
 export const getByTitle: GetByBoundAttribute
 export const getAllByTitle: AllByBoundAttribute
-export const queryByValue: QueryByBoundAttribute
-export const queryAllByValue: AllByBoundAttribute
-export const getByValue: GetByBoundAttribute
-export const getAllByValue: AllByBoundAttribute
-export const queryByDisplayValue: QueryByBoundAttribute
-export const queryAllByDisplayValue: AllByBoundAttribute
+export const queryByTitle: QueryByBoundAttribute
+export const queryAllByTitle: AllByBoundAttribute
+export const findByTitle: FindByBoundAttribute
+export const findAllByTitle: FindAllByBoundAttribute
 export const getByDisplayValue: GetByBoundAttribute
 export const getAllByDisplayValue: AllByBoundAttribute
-export const queryByRole: QueryByBoundAttribute
-export const queryAllByRole: AllByBoundAttribute
+export const queryByDisplayValue: QueryByBoundAttribute
+export const queryAllByDisplayValue: AllByBoundAttribute
+export const findByDisplayValue: FindByBoundAttribute
+export const findAllByDisplayValue: FindAllByBoundAttribute
 export const getByRole: GetByBoundAttribute
 export const getAllByRole: AllByBoundAttribute
+export const queryByRole: QueryByBoundAttribute
+export const queryAllByRole: AllByBoundAttribute
+export const findByRole: FindByBoundAttribute
+export const findAllByRole: FindAllByBoundAttribute
+export const getByTestId: GetByBoundAttribute
+export const getAllByTestId: AllByBoundAttribute
+export const queryByTestId: QueryByBoundAttribute
+export const queryAllByTestId: AllByBoundAttribute
+export const findByTestId: FindByBoundAttribute
+export const findAllByTestId: FindAllByBoundAttribute
+export const getBySelectText: GetByBoundAttribute
+export const getAllBySelectText: AllByBoundAttribute
+export const queryBySelectText: QueryByBoundAttribute
+export const queryAllBySelectText: AllByBoundAttribute
+export const findBySelectText: FindByBoundAttribute
+export const findAllBySelectText: FindAllByBoundAttribute
+export const getByValue: GetByBoundAttribute
+export const getAllByValue: AllByBoundAttribute
+export const queryByValue: QueryByBoundAttribute
+export const queryAllByValue: AllByBoundAttribute
+export const findByValue: FindByBoundAttribute
+export const findAllByValue: FindAllByBoundAttribute

--- a/typings/queries.d.ts
+++ b/typings/queries.d.ts
@@ -113,11 +113,7 @@ export const getBySelectText: GetByBoundAttribute
 export const getAllBySelectText: AllByBoundAttribute
 export const queryBySelectText: QueryByBoundAttribute
 export const queryAllBySelectText: AllByBoundAttribute
-export const findBySelectText: FindByBoundAttribute
-export const findAllBySelectText: FindAllByBoundAttribute
 export const getByValue: GetByBoundAttribute
 export const getAllByValue: AllByBoundAttribute
 export const queryByValue: QueryByBoundAttribute
 export const queryAllByValue: AllByBoundAttribute
-export const findByValue: FindByBoundAttribute
-export const findAllByValue: FindAllByBoundAttribute

--- a/typings/queries.d.ts
+++ b/typings/queries.d.ts
@@ -1,5 +1,5 @@
-import { Matcher, MatcherOptions } from './matches'
-import { SelectorMatcherOptions } from './query-helpers'
+import {Matcher, MatcherOptions} from './matches'
+import {SelectorMatcherOptions} from './query-helpers'
 
 export type QueryByBoundAttribute = (
   container: HTMLElement,

--- a/typings/wait-for-element.d.ts
+++ b/typings/wait-for-element.d.ts
@@ -1,8 +1,10 @@
+export interface WaitForElementOptions {
+  container?: HTMLElement
+  timeout?: number
+  mutationObserverOptions?: MutationObserverInit
+}
+
 export function waitForElement<T>(
   callback: () => T,
-  options?: {
-    container?: HTMLElement
-    timeout?: number
-    mutationObserverOptions?: MutationObserverInit
-  },
+  options?: WaitForElementOptions,
 ): Promise<T>


### PR DESCRIPTION
**What**:
- Addresses #226 including type definitions for findBy and findAllBy

**Why**:
- Helps users of this package working with typescript

**How**:
- Followed the outlined queries documentation to ensure all listed queries now have findBy and findAllBy type definitions.
- Adjusts order so it reads in the same order as listed in the API documentation.

**Checklist**:
- [ ] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) NA
- [X ] Typescript definitions updated
- [ ] Tests NA
- [X] Ready to be merged

I have left `ByValue`, `BySelectText` as is for now since there is a dedicated issue to removing the deprecated queries.
