### PR TITLE
fix: add implementation for contenteditable input events

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -169,6 +169,13 @@ test('assigning a value to a target that cannot have a value throws an error', (
   )
 })
 
+test('triggers an input event on a contenteditable target', () => {
+  const node = document.createElement('div')
+  node.setAttribute('contenteditable', 'true')
+  fireEvent.change(node, {target: {value: 'i am a rich editor'}})
+  expect(node.textContent).toEqual('i am a rich editor')
+})
+
 test('assigning the files property on an input', () => {
   const node = document.createElement('input')
   const file = new document.defaultView.File(['(⌐□_□)'], 'chucknorris.png', {

--- a/src/events.js
+++ b/src/events.js
@@ -349,6 +349,11 @@ function setNativeValue(element, value) {
     prototypeValueSetter.call(element, value)
   } /* istanbul ignore next (I don't want to bother) */ else if (valueSetter) {
     valueSetter.call(element, value)
+  } else if (
+    element.isContentEditable ||
+    element.getAttribute('contenteditable') == 'true'
+  ) {
+    element.textContent = value
   } else {
     throw new Error('The given element does not have a value setter')
   }


### PR DESCRIPTION
Firing a change event on an element that is `contenteditable` enabled throws an error with the following message: `The given element does not have a value setter`

**What**:
Changed the `fireEvent.change` api to transparently check to see if the element is `contenteditable` and if so, set the element's textContent based on the event's target value.

**Why**:
Input events are supported on non form elements if the element has `contenteditable` enabled see https://developer.mozilla.org/en-US/docs/Web/Events/input for more information.

**How**:
There are no new apis or changes to the interface of existing apis.  The existing api handles the `contenteditable` case without changes to how it handles changes to form elements.  

**Checklist**:

- [ ] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [ ] Typescript definitions updated N/A
- [X] Tests 
- [ ] Ready to be merged 

One thing I'm not confident about is whether delegating an input event's target value to element's `textContent` setter is a good idea.  In seems to make sense in many situations but probably not all
