### PR TITLE
feat: add asyncWrapper config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,14 @@
 // './queries' are query functions.
 let config = {
   testIdAttribute: 'data-testid',
+  // this is to support React's async `act` function.
+  // forcing react-testing-library to wrap all async functions would've been
+  // a total nightmare (consider wrapping every findBy* query and then also
+  // updating `within` so those would be wrapped too. Total nightmare).
+  // so we have this config option that's really only intended for
+  // react-testing-library to use. For that reason, this feature will remain
+  // undocumented.
+  asyncWrapper: cb => cb(),
 }
 
 export function configure(newConfig) {

--- a/src/wait-for-dom-change.js
+++ b/src/wait-for-dom-change.js
@@ -1,4 +1,5 @@
 import {newMutationObserver, getDocument, getSetImmediate} from './helpers'
+import {getConfig} from './config'
 
 function waitForDomChange({
   container = getDocument(),
@@ -36,4 +37,8 @@ function waitForDomChange({
   })
 }
 
-export {waitForDomChange}
+function waitForDomChangeWrapper(...args) {
+  return getConfig().asyncWrapper(() => waitForDomChange(...args))
+}
+
+export {waitForDomChangeWrapper as waitForDomChange}

--- a/src/wait-for-element-to-be-removed.js
+++ b/src/wait-for-element-to-be-removed.js
@@ -1,4 +1,5 @@
 import {getDocument, getSetImmediate, newMutationObserver} from './helpers'
+import {getConfig} from './config'
 
 function waitForElementToBeRemoved(
   callback,
@@ -69,4 +70,8 @@ function waitForElementToBeRemoved(
   })
 }
 
-export {waitForElementToBeRemoved}
+function waitForElementToBeRemovedWrapper(...args) {
+  return getConfig().asyncWrapper(() => waitForElementToBeRemoved(...args))
+}
+
+export {waitForElementToBeRemovedWrapper as waitForElementToBeRemoved}

--- a/src/wait-for-element.js
+++ b/src/wait-for-element.js
@@ -1,4 +1,5 @@
 import {newMutationObserver, getDocument, getSetImmediate} from './helpers'
+import {getConfig} from './config'
 
 function waitForElement(
   callback,
@@ -54,4 +55,8 @@ function waitForElement(
   })
 }
 
-export {waitForElement}
+function waitForElementWrapper(...args) {
+  return getConfig().asyncWrapper(() => waitForElement(...args))
+}
+
+export {waitForElementWrapper as waitForElement}

--- a/src/wait.js
+++ b/src/wait.js
@@ -1,7 +1,12 @@
 import waitForExpect from 'wait-for-expect'
+import {getConfig} from './config'
 
 function wait(callback = () => {}, {timeout = 4500, interval = 50} = {}) {
   return waitForExpect(callback, timeout, interval)
 }
 
-export {wait}
+function waitWrapper(...args) {
+  return getConfig().asyncWrapper(() => wait(...args))
+}
+
+export {waitWrapper as wait}

--- a/typings/config.d.ts
+++ b/typings/config.d.ts
@@ -1,5 +1,6 @@
 export interface IConfig {
   testIdAttribute: string
+  asyncWrapper<T>(cb: Function): Promise<T>
 }
 
 export interface IConfigFn {


### PR DESCRIPTION
**What**: add asyncWrapper config

**Why**: At first glance you're probably thinking: "Oh no, no no. No way." But think for a moment that react-testing-library can't just export its own `wait*` APIs and make everything work, because the `findBy*` queries all use the `waitForElement` API that's exposed by dom-testing-library (not the one that would be wrapped by react-testing-library), so we have two options:

1. Write wrapping code for every `findBy*` query that exists today and keep that updated in the future if new queries are ever added. This would include wrapping `within`/`getQueriesForElement` so the `findBy*` queries from those are are wrapped. In addition to wrapping all the `wait*` utilities.
2. Allow configuration of the dom-testing-library `wait*` APIs as this PR does

I don't like either of those solutions, but I dislike solution 2 WAY less.

**How**:

Add a config option called `asyncWrapper` and wrap all the `wait*` APIs in that. The default just calls the callback so there's no real cost to doing it this way. I've tested this locally with and without my changes to react-testing-library and it works great (so people using a new dom-testing-library and an old react-testing-library will be fine). When I update react-testing-library I'll make sure to add a version bump to dom-testing-library so we don't wind up with the opposite situation.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [x] Typescript definitions updated (I think so?)
- [x] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
