### PR TITLE
findBy* typings: Remove Error as a possible return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ your team down.
 
 The `dom-testing-library` is a very light-weight solution for testing DOM nodes
 (whether simulated with [`JSDOM`](https://github.com/jsdom/jsdom) as provided by
-default with [jest][] or in the browser). The main utilities it provides involve
+default with [Jest][] or in the browser). The main utilities it provides involve
 querying the DOM for nodes in a way that's similar to how the user finds
 elements on the page. In this way, the library helps ensure your tests give you
 confidence in your UI code. The `dom-testing-library`'s primary guiding

--- a/typings/queries.d.ts
+++ b/typings/queries.d.ts
@@ -19,7 +19,7 @@ export type FindAllByBoundAttribute = (
   id: Matcher,
   options?: MatcherOptions,
   waitForElementOptions?: WaitForElementOptions
-) => Promise<HTMLElement[]> | Error
+) => Promise<HTMLElement[]>
 
 export type GetByBoundAttribute = (
   container: HTMLElement,
@@ -32,7 +32,7 @@ export type FindByBoundAttribute = (
   id: Matcher,
   options?: MatcherOptions,
   waitForElementOptions?: WaitForElementOptions
-) => Promise<HTMLElement> | Error
+) => Promise<HTMLElement>
 
 export type QueryByText = (
   container: HTMLElement,
@@ -51,7 +51,7 @@ export type FindAllByText = (
   id: Matcher,
   options?: SelectorMatcherOptions,
   waitForElementOptions?: WaitForElementOptions
-) => Promise<HTMLElement[]> | Error
+) => Promise<HTMLElement[]>
 
 export type GetByText = (
   container: HTMLElement,
@@ -64,7 +64,7 @@ export type FindByText = (
   id: Matcher,
   options?: SelectorMatcherOptions,
   waitForElementOptions?: WaitForElementOptions
-) => Promise<HTMLElement> | Error
+) => Promise<HTMLElement>
 
 export const getByLabelText: GetByText
 export const getAllByLabelText: AllByText


### PR DESCRIPTION
**What**:

- Remove `| Error` from findBy* return typings.

<!-- Why are these changes necessary? -->

**Why**:

- The findBy* functions throw errors, so an Error will never actually be returned. Similar to the getBy* functions.
- See https://github.com/kentcdodds/dom-testing-library/issues/226#issuecomment-482396530 for more context.

**How**:

- I updated each of the 4 return typings for the findBy* functions and removed `| Error`.

**Checklist**:

- [ ] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [x] Typescript definitions updated
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

