### PR TITLE
Fix typings of getQueriesForElement

### DIFF
--- a/typings/get-queries-for-element.d.ts
+++ b/typings/get-queries-for-element.d.ts
@@ -13,9 +13,7 @@ export type BoundFunction<T> = T extends (
   : never
 export type BoundFunctions<T> = {[P in keyof T]: BoundFunction<T[P]>}
 
-export function getQueriesForElement(
+export function getQueriesForElement<T = typeof queries>(
   element: HTMLElement,
-  queriesToBind?:
-    | BoundFunctions<typeof queries>
-    | BoundFunctions<typeof queries>[],
-): BoundFunctions<typeof queries>
+  queriesToBind?: T,
+): BoundFunctions<T>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fix typings of getQueriesForElement function

<!-- Why are these changes necessary? -->

**Why**:
There are currently two problems:
1. Type of `queriesToBind` parameter is `BoundFunctions<typeof queries> | BoundFunctions<typeof queries>[]` which is IMO incorrect because the function is doing the binding and thus should receive unbound queries.
1. Type parameter of `BoundFunctions` is hardcoded to `typeof queries` which prevents binding of custom queries

<!-- How were these changes implemented? -->

**How**:
1. Parametrised `getQueriesForElement` to enable binding custom queries
1. Changed type of `queriesToBind` to type parameter

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [x] Typescript definitions updated
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
