### PR TITLE
feat: add debug to default queries (#249)

### DIFF
--- a/src/__tests__/get-queries-for-element.js
+++ b/src/__tests__/get-queries-for-element.js
@@ -6,6 +6,7 @@ test('uses default queries + debug method that prints out the given DOM element'
   const {debug, ...defaultBoundQueries} = getQueriesForElement(container)
   expect(Object.keys(defaultBoundQueries)).toEqual(Object.keys(queries))
   expect(debug).toBeDefined()
+  debug() // need to invoke the function for coverage
 })
 
 test('accepts custom queries', () => {

--- a/src/__tests__/get-queries-for-element.js
+++ b/src/__tests__/get-queries-for-element.js
@@ -1,10 +1,11 @@
 import {getQueriesForElement} from '../get-queries-for-element'
 import {queries} from '..'
 
-test('uses default queries', () => {
+test('uses default queries + debug method that prints out the given DOM element', () => {
   const container = document.createElement('div')
-  const boundQueries = getQueriesForElement(container)
-  expect(Object.keys(boundQueries)).toEqual(Object.keys(queries))
+  const {debug, ...defaultBoundQueries} = getQueriesForElement(container)
+  expect(Object.keys(defaultBoundQueries)).toEqual(Object.keys(queries))
+  expect(debug).toBeDefined()
 })
 
 test('accepts custom queries', () => {

--- a/src/get-queries-for-element.js
+++ b/src/get-queries-for-element.js
@@ -1,4 +1,10 @@
 import * as defaultQueries from './queries'
+import {prettyDOM} from './pretty-dom'
+
+function debug(...args) {
+  // eslint-disable-next-line no-console
+  console.log(prettyDOM(...args))
+}
 
 /**
  * @typedef {{[key: string]: Function}} FuncMap
@@ -9,7 +15,7 @@ import * as defaultQueries from './queries'
  * @param {FuncMap} queries object of functions
  * @returns {FuncMap} returns object of functions bound to container
  */
-function getQueriesForElement(element, queries = defaultQueries) {
+function getQueriesForElement(element, queries = {debug, ...defaultQueries}) {
   return Object.keys(queries).reduce((helpers, key) => {
     const fn = queries[key]
     helpers[key] = fn.bind(null, element)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Addresses #249 adding a debug method to the default list of queries

<!-- Why are these changes necessary? -->

**Why**:

Helps other developers to debug part of the DOM tree (by having the debug function on `within` API)

<!-- How were these changes implemented? -->

**How**:

I thought of exporting this debug method in the queries file but this is not a query and wouldn't make sense to have it there. Then I decided to extend the default queries in `getQueriesForElement`. Thus we don't touch the queries and the developers can still use their own custom queries.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs)
  - I have created the issue in the project and will work on that soon (https://github.com/alexkrolick/testing-library-docs/issues/82)
- [ ] Typescript definitions updated
- [x] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I still have 3 questions:

1 - Do we need to update Typescript definitions? 🤔

2 - Is it fine to have a function that does `console.log` in the `dom-testing-library` given that other libraries use it? (I know it would be fine for `react-testing-library` but I am not 100% sure about the others)

3 - Can we get rid of this line?
https://github.com/kentcdodds/react-testing-library/blob/master/src/index.js#L62
Since `getQueriesForElement` will now return the `debug` function down in the line 81 I think it is safe, no?